### PR TITLE
Fix docker compose when node modules is empty

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:10.16.0
-
-VOLUME /home/user/code
-WORKDIR /home/user/code
-
-RUN yarn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,22 +27,20 @@ services:
       - postgres
   documentation:
     restart: always
-    build:
-      context: .
-      dockerfile: ./api/Dockerfile.local
-      args:
-        PORT: '${DOCS_PORT}'
-    command: 'mkdocs serve --dev-addr=0.0.0.0:${DOCS_PORT}'
+    image: squidfunk/mkdocs-material
     volumes:
-      - ./:/home/user/code
+      - ${PWD}:/docs
     ports:
-      - '${DOCS_PORT}:${DOCS_PORT}'
+      - '${DOCS_PORT}:8000'
   client:
     ports:
       - '${CLIENT_PORT}:${CLIENT_PORT}'
-    build:
-      context: ./client/
-    command: bash -c "API_URL=http://localhost:${HTTP_PORT} yarn run dev -p ${CLIENT_PORT}"
+    image: node:10.16.0
+    build: ./client
+    command: >
+      bash -c "cd /home/user/code &&
+               yarn install &&
+               API_URL=http://localhost:${HTTP_PORT} yarn run dev -p ${CLIENT_PORT}"
     volumes:
       - ./client:/home/user/code
       - ./client/node_modules:/home/user/code/node_modules
@@ -52,9 +50,11 @@ services:
   storybook:
     ports:
       - '${STORYBOOK_PORT}:${STORYBOOK_PORT}'
-    build:
-      context: ./client/
-    command: bash -c "API_URL=http://localhost:${HTTP_PORT} yarn run storybook --quiet -p ${STORYBOOK_PORT}"
+    image: node:10.16.0
+    build: ./client
+    command: >
+      bash -c "cd /home/user/code &&
+               API_URL=http://localhost:${HTTP_PORT} yarn run storybook --quiet -p ${STORYBOOK_PORT}"
     volumes:
       - ./client:/home/user/code
       - ./client/node_modules:/home/user/code/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
     ports:
       - '${CLIENT_PORT}:${CLIENT_PORT}'
     image: node:10.16.0
-    build: ./client
     command: >
       bash -c "cd /home/user/code &&
                yarn install &&
@@ -51,7 +50,6 @@ services:
     ports:
       - '${STORYBOOK_PORT}:${STORYBOOK_PORT}'
     image: node:10.16.0
-    build: ./client
     command: >
       bash -c "cd /home/user/code &&
                API_URL=http://localhost:${HTTP_PORT} yarn run storybook --quiet -p ${STORYBOOK_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,26 +35,16 @@ services:
   client:
     ports:
       - '${CLIENT_PORT}:${CLIENT_PORT}'
+      - '${STORYBOOK_PORT}:${STORYBOOK_PORT}'
     image: node:10.16.0
     command: >
       bash -c "cd /home/user/code &&
                yarn install &&
-               API_URL=http://localhost:${HTTP_PORT} yarn run dev -p ${CLIENT_PORT}"
+               (API_URL=http://localhost:${HTTP_PORT} yarn run storybook --quiet -p ${STORYBOOK_PORT} &
+               API_URL=http://localhost:${HTTP_PORT} yarn run dev -p ${CLIENT_PORT})"
     volumes:
       - ./client:/home/user/code
       - ./client/node_modules:/home/user/code/node_modules
       - ./client/.next:/home/user/code/.next
     depends_on:
       - api
-  storybook:
-    ports:
-      - '${STORYBOOK_PORT}:${STORYBOOK_PORT}'
-    image: node:10.16.0
-    command: >
-      bash -c "cd /home/user/code &&
-               API_URL=http://localhost:${HTTP_PORT} yarn run storybook --quiet -p ${STORYBOOK_PORT}"
-    volumes:
-      - ./client:/home/user/code
-      - ./client/node_modules:/home/user/code/node_modules
-    depends_on:
-      - client


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Looks like the big docker-compose file was failing when the `node_modules` folder was empty. This folder was mounted as a volume in the image. 

This fixes the problem, however, on the first run, the storybook image will fail because it needs for the client to be launched first.

This is a temporary solution I need to think if there's a better one.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
