### PR TITLE
adding default medium size button styles

### DIFF
--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -3,8 +3,8 @@ import { normalizeColor } from 'grommet/utils'
 const theme = {
   button: {
     border: {
-      width: '1px',
       radius: '4px'
+      width: '1px',
     },
     padding: {
       horizontal: '24px',

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -3,12 +3,23 @@ import { normalizeColor } from 'grommet/utils'
 const theme = {
   button: {
     border: {
-      radius: '4px',
-      width: '1px'
+      width: '1px',
+      radius: '4px'
     },
     padding: {
       horizontal: '24px',
       vertical: '7px' // 8px - 1px for border
+    },
+    size: {
+      medium: {
+        border: {
+          radius: '4px'
+        },
+        padding: {
+          horizontal: '24px',
+          vertical: '7px' // 8px - 1px for border
+        }
+      }
     },
     disabled: {
       opacity: 1

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -3,8 +3,8 @@ import { normalizeColor } from 'grommet/utils'
 const theme = {
   button: {
     border: {
-      radius: '4px'
-      width: '1px',
+      radius: '4px',
+      width: '1px'
     },
     padding: {
       horizontal: '24px',


### PR DESCRIPTION
## Issue Number

Fixes buttons for search by adding styles for medium to match default

## Purpose/Implementation Notes

Duplicates configs in buttons theme to match medium/default styles.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Storybook

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![Screen Shot 2020-04-08 at 12 36 21 PM](https://user-images.githubusercontent.com/1075609/78809886-954a8b80-7995-11ea-8717-ae2e69f50561.png)
![Screen Shot 2020-04-08 at 12 36 18 PM](https://user-images.githubusercontent.com/1075609/78809887-95e32200-7995-11ea-945d-d90ef746f57d.png)
![Screen Shot 2020-04-08 at 12 36 15 PM](https://user-images.githubusercontent.com/1075609/78809888-95e32200-7995-11ea-8452-8cea43b20c02.png)

