### PR TITLE
Move resource templates into group in storybook

### DIFF
--- a/client/src/resources/resources.stories.js
+++ b/client/src/resources/resources.stories.js
@@ -12,7 +12,7 @@ export function formatSentenceCase(str) {
 }
 
 for (const key of Object.keys(Mappings)) {
-  storiesOf(`${formatSentenceCase(key)}`, module)
+  storiesOf(`Resources/${formatSentenceCase(key)}`, module)
     .add('SearchResult', () => {
       return (
         <Grommet theme={theme}>


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Just noticed that we can group the stories in storybook.

![image](https://user-images.githubusercontent.com/1882507/79386864-c2b8ab80-7f38-11ea-8c9f-c6c74a2a9b22.png)
