### PR TITLE
version search + valid json

### DIFF
--- a/api/dev_data/materials.json
+++ b/api/dev_data/materials.json
@@ -275,7 +275,7 @@
         "gender": "Male",
         "age": "15",
         "diagnosis": "Stage 4 Lymphoma",
-        "consent_to_share": "False",
+        "consent_to_share": false,
         "ethnicity": "Hispanic",
         "prior_treatment_protocol": "10 mg Anastrozole daily",
         "current_treatment_drug": "Anastrozole",

--- a/api/resources_portal/models/documents.py
+++ b/api/resources_portal/models/documents.py
@@ -1,3 +1,5 @@
+import json
+
 from django_elasticsearch_dsl import Document, Index, fields
 from elasticsearch_dsl import analyzer
 
@@ -93,10 +95,7 @@ class MaterialDocument(Document):
     embargo_date = fields.DateField()
 
     def prepare_additional_metadata(self, instance):
-        metadata_string = str(instance.additional_metadata)
-        metadata_string = metadata_string.strip("{")
-        metadata_string = metadata_string.strip("}")
-        return metadata_string
+        return json.dumps(instance.additional_metadata)
 
     class Django:
         model = Material

--- a/api/resources_portal/urls.py
+++ b/api/resources_portal/urls.py
@@ -35,5 +35,5 @@ urlpatterns = [
     # the 'api-root' from django rest-frameworks default router
     # http://www.django-rest-framework.org/api-guide/routers/#defaultrouter
     re_path(r"^$", RedirectView.as_view(url=reverse_lazy("api-root"), permanent=False)),
-    path("search/", include(search_router.urls)),
+    path("v1/search/", include(search_router.urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/api/resources_portal/views/document_views.py
+++ b/api/resources_portal/views/document_views.py
@@ -32,8 +32,8 @@ class MaterialDocumentSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField(read_only=True)
     updated_at = serializers.DateTimeField(read_only=True)
     organism = serializers.ListField(read_only=True)
-    has_publication = serializers.CharField(read_only=True)
-    has_pre_print = serializers.CharField(read_only=True)
+    has_publication = serializers.BooleanField(read_only=True)
+    has_pre_print = serializers.BooleanField(read_only=True)
     additional_info = serializers.CharField(read_only=True)
     contact_name = serializers.CharField(read_only=True)
     contact_email = serializers.CharField(read_only=True)
@@ -41,7 +41,7 @@ class MaterialDocumentSerializer(serializers.Serializer):
     pre_print_doi = serializers.CharField(read_only=True)
     pre_print_title = serializers.CharField(read_only=True)
     citation = (serializers.CharField(read_only=True),)
-    needs_shipping_info = serializers.CharField(read_only=True)
+    needs_shipping_info = serializers.BooleanField(read_only=True)
     embargo_date = serializers.DateField(read_only=True)
     contact_user = serializers.SerializerMethodField(read_only=True)
     organization = serializers.SerializerMethodField(read_only=True)
@@ -58,8 +58,7 @@ class MaterialDocumentSerializer(serializers.Serializer):
         return loads(dumps(obj.mta_attachment.to_dict()))
 
     def get_additional_metadata(self, obj):
-        # this pre-processes the JSON string in django form into a form that loads can take.
-        return loads("{" + obj.additional_metadata.replace('"', "").replace("'", '"') + "}")
+        return loads(obj.additional_metadata)
 
     class Meta:
         model = Material


### PR DESCRIPTION
## Issue Number

#157 

## Purpose/Implementation Notes

* version the api
* material document serializer should return valid json for boolean values
* index json fields as text by calling json.dumps

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None really just reindexed and checked the api search output

The ./run_tests passed but I'm not sure if they should be updated after moving the search endpoints to v1

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

