### PR TITLE
Materials permissions and auth

### DIFF
--- a/api/resources_portal/models/organization.py
+++ b/api/resources_portal/models/organization.py
@@ -38,3 +38,5 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
     if created:
         # when a new organization is created, assign permission to it's owner
         assign_perm("approve_requests", instance.owner, instance)
+        assign_perm("add_resources", instance.owner, instance)
+        assign_perm("add_members_and_manage_permissions", instance.owner, instance)

--- a/api/resources_portal/test/views/test_material.py
+++ b/api/resources_portal/test/views/test_material.py
@@ -19,19 +19,37 @@ class TestMaterialListTestCase(APITestCase):
     def setUp(self):
         self.url = reverse("material-list")
         self.user = UserFactory()
+        self.user_without_perms = UserFactory()
         self.organization = OrganizationFactory(owner=self.user)
         self.material = MaterialFactory(contact_user=self.user, organization=self.organization)
         self.material_data = model_to_dict(self.material)
 
     def test_post_request_with_no_data_fails(self):
+        self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, {})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_request_with_valid_data_succeeds(self):
+        self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, self.material_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         self.assertEqual(self.material.category, response.json()["category"])
+
+    def test_post_request_without_permission_forbidden(self):
+        self.client.force_authenticate(user=self.user_without_perms)
+        response = self.client.post(self.url, self.material_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_post_request_from_unauthenticated_forbidden(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.post(self.url, self.material_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_request_succeeds(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class TestSingleMaterialTestCase(APITestCase):
@@ -40,23 +58,66 @@ class TestSingleMaterialTestCase(APITestCase):
     """
 
     def setUp(self):
-        self.material = MaterialFactory()
+        self.user = UserFactory()
+        self.user_without_perms = UserFactory()
+        self.organization = OrganizationFactory(owner=self.user)
+        self.material = MaterialFactory(contact_user=self.user, organization=self.organization)
         self.url = reverse("material-detail", args=[self.material.id])
 
     def test_get_request_returns_a_given_material(self):
+        self.client.force_authenticate(user=None)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_put_request_updates_a_material(self):
+        self.client.force_authenticate(user=self.user)
         material_json = self.client.get(self.url).json()
 
         new_url = fake.url()
         material_json["url"] = new_url
         material_json["contact_user"] = material_json["contact_user"]["id"]
 
-        # TODO: this should require authentication
         response = self.client.put(self.url, material_json)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         material = Material.objects.get(pk=self.material.id)
         self.assertEqual(material.url, new_url)
+
+    def test_put_request_without_permission_forbidden(self):
+        self.client.force_authenticate(user=self.user_without_perms)
+        material_json = self.client.get(self.url).json()
+
+        new_url = fake.url()
+        material_json["url"] = new_url
+        material_json["contact_user"] = material_json["contact_user"]["id"]
+
+        response = self.client.put(self.url, material_json)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_put_request_from_unauthenticated_forbidden(self):
+        self.client.force_authenticate(user=None)
+        material_json = self.client.get(self.url).json()
+
+        new_url = fake.url()
+        material_json["url"] = new_url
+        material_json["contact_user"] = material_json["contact_user"]["id"]
+
+        response = self.client.put(self.url, material_json)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_request_deletes_a_material(self):
+        self.client.force_authenticate(user=self.user)
+        material_id = self.material.id
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Material.objects.filter(id=material_id).count(), 0)
+
+    def test_delete_request_without_permission_forbidden(self):
+        self.client.force_authenticate(user=self.user_without_perms)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_request_from_unauthenticated_forbidden(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/api/resources_portal/views/material.py
+++ b/api/resources_portal/views/material.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from resources_portal.models import Material, Organization
+from resources_portal.models import Material
 from resources_portal.views.user import UserSerializer
 
 

--- a/api/resources_portal/views/material.py
+++ b/api/resources_portal/views/material.py
@@ -32,8 +32,6 @@ class MaterialDetailSerializer(MaterialSerializer):
 
 class HasAddResources(BasePermission):
     def has_object_permission(self, request, view, obj):
-        print("********************************")
-
         return request.user.has_perm("add_resources", obj.organization)
 
 


### PR DESCRIPTION
## Issue Number

#169 

## Purpose/Implementation Notes

This adds auth and permissions for the materials route.

## Types of changes

This adds permission checks in the viewset, tests for permissions, and a slight modification to how Organization adds permissions.

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests only baybee

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
