### PR TITLE
Searches With Post Filters

### DIFF
--- a/api/resources_portal/views/document_views.py
+++ b/api/resources_portal/views/document_views.py
@@ -10,6 +10,7 @@ from django_elasticsearch_dsl_drf.filter_backends import (
     FacetedSearchFilterBackend,
     FilteringFilterBackend,
     OrderingFilterBackend,
+    PostFilterFilteringFilterBackend,
 )
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination as ESLimitOffsetPagination
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
@@ -172,7 +173,9 @@ class MaterialDocumentView(DocumentViewSet):
         DefaultOrderingFilterBackend,
         CompoundSearchFilterBackend,
         FacetedSearchFilterBackend,
+        PostFilterFilteringFilterBackend,
     ]
+
     lookup_field = "id"
 
     # Define search fields
@@ -236,14 +239,13 @@ class MaterialDocumentView(DocumentViewSet):
     }
     faceted_search_param = "facet"
 
-    def list(self, request, *args, **kwargs):
-        # If a single faceted_search_field is in the request, make it global.
-        # response.data["facets"] will then include all terms for that facet.
-        applied_facets = set(request.query_params) & set(self.faceted_search_fields)
-        if len(applied_facets) == 1:
-            facet = applied_facets.pop()
-            self.faceted_search_fields[facet]["global"] = True
+    # Specify post filter fields
+    post_filter_fields = {
+        "category_pf": {"field": "category"},
+        "organism_pf": {"field": "organism"},
+    }
 
+    def list(self, request, *args, **kwargs):
         response = super(MaterialDocumentView, self).list(request, args, kwargs)
         response.data["facets"] = self.transform_es_facets(response.data["facets"])
         return response

--- a/api/resources_portal/views/document_views.py
+++ b/api/resources_portal/views/document_views.py
@@ -237,6 +237,13 @@ class MaterialDocumentView(DocumentViewSet):
     faceted_search_param = "facet"
 
     def list(self, request, *args, **kwargs):
+        # If a single faceted_search_field is in the request, make it global.
+        # response.data["facets"] will then include all terms for that facet.
+        applied_facets = set(request.query_params) & set(self.faceted_search_fields)
+        if len(applied_facets) == 1:
+            facet = applied_facets.pop()
+            self.faceted_search_fields[facet]["global"] = True
+
         response = super(MaterialDocumentView, self).list(request, args, kwargs)
         response.data["facets"] = self.transform_es_facets(response.data["facets"])
         return response

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -37,6 +37,36 @@ A list of all filterable fields for a given search will be returned with the sea
 ```
 Note that only Materials are filterable.
 
+### Post Filters
+
+Post Filters are filters that are not applied to the facet aggregations. They are useful for iteratively creating a search query.
+Filters return facets with aggregations that show how many *are* contained in the search results.
+Post Filters return facets with aggregations that show how many *would* be contained in the search result if included - in addition to what is contained in the results.
+
+The Materials search endpoint currently supports two Post Filter parameters: ```category_pf```` and ```organism_pf```.
+They accept the same values as the ```category``` and ```organism``` filters respectively.
+
+For example the request:  ```search/materials?search=zebrafish&category_pf=DATASET```
+Would give the following reponse:
+```json
+"facets": {
+    "category": {
+        "DATASET": 4,
+        "MODEL_ORGANISM": 4,
+        "CELL_LINE": 2,
+        "OTHER": 2,
+        "PLASMID": 2,
+        "PROTOCOL": 2,
+        "PDX": 1
+    }
+},
+"results": [Array of 4 materials where category=DATASET]
+```
+As you can see above the facets contain the aggregation counts for all material categories and is not limited to only ```DATASET```
+Those aggregation counts are affected by the search parameter and any other filtering included in the request. Only the Post Filters are ommited during aggregation.
+
+Note: Post Filters can be combined with other Filters but Filters will always be applied before Post Filters.
+
 ### Ordering
 
 Ordering can be performed on the ```created_at``` and ```updated_at``` fields of any object, as well as the following fields:

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -43,7 +43,7 @@ Post Filters are filters that are not applied to the facet aggregations. They ar
 Filters return facets with aggregations that show how many *are* contained in the search results.
 Post Filters return facets with aggregations that show how many *would* be contained in the search result if included - in addition to what is contained in the results.
 
-The Materials search endpoint currently supports two Post Filter parameters: ```category_pf```` and ```organism_pf```.
+The Materials search endpoint currently supports two Post Filter parameters: ```category_pf``` and ```organism_pf```.
 They accept the same values as the ```category``` and ```organism``` filters respectively.
 
 For example the request:  ```search/materials?search=zebrafish&category_pf=DATASET```
@@ -60,7 +60,7 @@ Would give the following reponse:
         "PDX": 1
     }
 },
-"results": [Array of 4 materials where category=DATASET]
+"results": ["Array of 4 materials where category=DATASET"]
 ```
 As you can see above the facets contain the aggregation counts for all material categories and is not limited to only ```DATASET```
 Those aggregation counts are affected by the search parameter and any other filtering included in the request. Only the Post Filters are ommited during aggregation.


### PR DESCRIPTION
## Issue Number

#175 

## Purpose/Implementation Notes

Aside: we might want to combine `has_publication` and `has_pre_print` into a single facet `publication` and have those as terms that would enable the below fix to be applicable to those options (which are presented in the same filter section)

The client needs to be able to see a way to expand search results when a single search facet is applied to the query. 

When you search for something like `zebrafish` you would perform the following search

Query: `/search/materials/?search=zebrafish`
Response:
```javascript
{
    "facets": {
        "category": {
            "DATASET": 4,
            "MODEL_ORGANISM": 4,
            "CELL_LINE": 2,
            "OTHER": 2,
            "PLASMID": 2,
            "PROTOCOL": 2,
            "PDX": 1
        }
    },
    "results": [15 results]
}
```
----
Currently if you want to start narrowing down by categories and you start with `DATASET` you would do something like

Query: `/search/materials/?search=zebrafish&category=DATASET`
Response:
```javascript
{
    "facets": {
        "category": {
            "DATASET": 4
        }
    },
    "results": [4 results]
}
```
-----
Automatically changing the outputs would mean overriding the name and filtering of the search fields ie (category, organism etc). That is not ideal.

The client knows when it wants to be able to show additional options. So it can instead use a different filter parameter that corresponds to the desired results filter. The attribute in the query tells the API that it would also like the aggregates for that field not to be affected by this filter. However the results will still be filtered by the specified categories.

Query: `/search/materials/?search=zebrafish&category_pf=DATASET`
Response:
```javascript
{
    "facets": {
        "category": {
            "DATASET": 4,
            "MODEL_ORGANISM": 4,
            "CELL_LINE": 2,
            "OTHER": 2,
            "PLASMID": 2,
            "PROTOCOL": 2,
            "PDX": 1
        }
    },
    "results": [4 results]
}
```

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

This probably should get a test but I wanted to discuss approach first.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Basic search query with 15 results

![Screen Shot 2020-05-16 at 12 22 58 PM](https://user-images.githubusercontent.com/1075609/82124882-0d178d00-9770-11ea-9697-635170744eef.png)

With post filter applied the results are limited to Dataset but the aggregates contain other options that are filtered by the search term.

![Screen Shot 2020-05-16 at 12 23 19 PM](https://user-images.githubusercontent.com/1075609/82124881-0d178d00-9770-11ea-9105-0d20d0e43b24.png)


