### PR TITLE
Add MaterialFacetedSearchFilterBackend

### DIFF
--- a/api/resources_portal/views/document_views.py
+++ b/api/resources_portal/views/document_views.py
@@ -17,6 +17,7 @@ from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from elasticsearch_dsl import TermsFacet
+from elasticsearch_dsl.query import Q
 from six import iteritems
 
 from resources_portal.models import Material, Organization, User
@@ -97,6 +98,42 @@ class MaterialDocumentSerializer(serializers.Serializer):
         )
 
 
+class MaterialFacetedSearchFilterBackend(FacetedSearchFilterBackend):
+    """
+    This is a modification to the FacetedSearchFilterBackend.
+    The main difference is we don't want the search result filters to be too narrow.
+    So we will only have the aggregates be filtered by the query params that are not for that aggregate.
+    In order to support this move any filter you want to show extra aggreates to post_filter_fields so
+    they aren't filtered out of the facet aggregations by default.
+
+    So if we are calulating the aggregates for `category` we apply all filters from `organism` etc
+    but not the requested categories.
+    """
+
+    def aggregate(self, request, queryset, view):
+        post_filter_fields = view.post_filter_fields.keys()
+        query_params = request.query_params.copy()
+        __facets = self.construct_facets(request, view)
+        for __field, __facet in iteritems(__facets):
+            agg = __facet["facet"].get_aggregation()
+            agg_filter = Q("match_all")
+
+            # loop over each query param and add to aggregate filter
+            # skip if query param is aleady applied (if it is not in post filters)
+            # skip if query param is the current facet aggregation
+            for query_field in query_params:
+                if query_field != __field and query_field in post_filter_fields:
+                    query_values = query_params.getlist(query_field, [])
+                    agg_filter = agg_filter + Q("terms", **{query_field: query_values})
+
+            # add the aggregate to the queryset
+            queryset.aggs.bucket("_filter_" + __field, "filter", filter=agg_filter).bucket(
+                __field, agg
+            )
+
+        return queryset
+
+
 ##
 # ElasticSearch powered Search and Filter
 ##
@@ -172,7 +209,7 @@ class MaterialDocumentView(DocumentViewSet):
         OrderingFilterBackend,
         DefaultOrderingFilterBackend,
         CompoundSearchFilterBackend,
-        FacetedSearchFilterBackend,
+        MaterialFacetedSearchFilterBackend,
         PostFilterFilteringFilterBackend,
     ]
 
@@ -199,14 +236,18 @@ class MaterialDocumentView(DocumentViewSet):
     # Define filtering fields
     filter_fields = {
         "id": {"field": "_id", "lookups": [LOOKUP_FILTER_RANGE, LOOKUP_QUERY_IN],},
-        "category": "category",
         "organization": {"field": "name"},
         "title": "title",
-        "organism": "organism",
         "contact_user.email": "contact_user.email",
         "contact_user.published_name": "contact_user.published_name",
-        "has_publication": "has_publication",
-        "has_pre_print": "has_pre_print",
+    }
+
+    # Define post filter fields
+    post_filter_fields = {
+        "category": {"field": "category"},
+        "organism": {"field": "organism"},
+        "has_publication": {"field": "has_publication"},
+        "has_pre_print": {"field": "has_pre_print"},
     }
 
     # Define ordering fields
@@ -238,12 +279,6 @@ class MaterialDocumentView(DocumentViewSet):
         "has_pre_print": {"field": "has_pre_print", "facet": TermsFacet, "enabled": True},
     }
     faceted_search_param = "facet"
-
-    # Specify post filter fields
-    post_filter_fields = {
-        "category_pf": {"field": "category"},
-        "organism_pf": {"field": "organism"},
-    }
 
     def list(self, request, *args, **kwargs):
         response = super(MaterialDocumentView, self).list(request, args, kwargs)

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -37,36 +37,6 @@ A list of all filterable fields for a given search will be returned with the sea
 ```
 Note that only Materials are filterable.
 
-### Post Filters
-
-Post Filters are filters that are not applied to the facet aggregations. They are useful for iteratively creating a search query.
-Filters return facets with aggregations that show how many *are* contained in the search results.
-Post Filters return facets with aggregations that show how many *would* be contained in the search result if included - in addition to what is contained in the results.
-
-The Materials search endpoint currently supports two Post Filter parameters: ```category_pf``` and ```organism_pf```.
-They accept the same values as the ```category``` and ```organism``` filters respectively.
-
-For example the request:  ```search/materials?search=zebrafish&category_pf=DATASET```
-Would give the following reponse:
-```json
-"facets": {
-    "category": {
-        "DATASET": 4,
-        "MODEL_ORGANISM": 4,
-        "CELL_LINE": 2,
-        "OTHER": 2,
-        "PLASMID": 2,
-        "PROTOCOL": 2,
-        "PDX": 1
-    }
-},
-"results": ["Array of 4 materials where category=DATASET"]
-```
-As you can see above the facets contain the aggregation counts for all material categories and is not limited to only ```DATASET```
-Those aggregation counts are affected by the search parameter and any other filtering included in the request. Only the Post Filters are ommited during aggregation.
-
-Note: Post Filters can be combined with other Filters but Filters will always be applied before Post Filters.
-
 ### Ordering
 
 Ordering can be performed on the ```created_at``` and ```updated_at``` fields of any object, as well as the following fields:


### PR DESCRIPTION
## Issue Number

#175 

## Purpose/Implementation Notes

Less elegant than just adding post filters. This PR instead just implements a  `MaterialFacetedSearchFilterBackend` which is a subclass of `FacetedSearchFilterBackend` that overrides the `aggregate` method and instead of ignoring the `post_filter_fields` it will apply them to the every aggregate except it's own.

In addition to the above it moves the appropriate `filter_fields` to the `post_filter_fileds` and removes the docs for the old post filter fields.

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested in the browser.

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![Screen Shot 2020-05-21 at 2 30 24 PM](https://user-images.githubusercontent.com/1075609/82593102-f3ab8200-9b6f-11ea-8832-217dc7a6f33a.png)

