### PR TITLE
Improve rportal command

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -22,6 +22,14 @@ i.e. the tests:
 rportal test-api
 ```
 
+Note that the tests are run with the Django unittest runner, so specific modules, classes, or methods may be specified in the standard unittest manner: https://docs.python.org/3/library/unittest.html#unittest-test-discovery.
+For example:
+```
+rportal test-api resources_portal.test.serializers.test_grant.TestGrantSerializer
+```
+
+will run all the tests in the TestGrantSerializer class.
+
 The dev server runs by default on port 8000 with the docs being served at 8001.
 If these ports are already in use on your local machine, you can run them at different ports with:
 

--- a/api/run_tests.sh
+++ b/api/run_tests.sh
@@ -2,5 +2,5 @@
 
 python wait_for_postgres.py
 python wait_for_elasticsearch.py
-coverage run ./manage.py test -v 2 --no-input
+coverage run ./manage.py test -v 2 --no-input "$@"
 coverage report -m

--- a/api/wait_for_elasticsearch.py
+++ b/api/wait_for_elasticsearch.py
@@ -25,3 +25,7 @@ while (datetime.now() - start < max_time) and not success:
         print("Waiting on elasticsearch to start....")
 
         time.sleep(1)
+
+if datetime.now() - start > max_time:
+    print("Elasticsearch never came up.")
+    exit(1)

--- a/bin/rportal
+++ b/bin/rportal
@@ -8,8 +8,13 @@ if not os.path.exists("./bin/rportal"):
     print("Please call rportal from the project's root")
     exit()
 
+# Docker compose uses the current directory in the network name. We
+# need to pass the network name into containers, so we have to know
+# what it is.
+project_folder = os.getcwd().split("/")[-1]
+
 # every docker-compose run api command looks like this
-run_api = "API_NETWORK=resources-portal_default docker-compose --env-file ./docker-compose.env run --rm api {}"
+run_api = f"API_NETWORK={project_folder}_default docker-compose --env-file ./docker-compose.env run --rm api {{}}"
 
 # list of available commands
 commands = {
@@ -23,7 +28,7 @@ commands = {
         'bash -c "./wait_for_elasticsearch.py && ./manage.py populate_test_database"'
     ),
     "recreate-schema": "./recreate_schema.sh",
-    "test-api": run_api.format('bash -c "./wait_for_elasticsearch.py && ./run_tests.sh"'),
+    "test-api": run_api.format('bash -c "./wait_for_elasticsearch.py && ./run_tests.sh {}"'),
     "makemigrations": run_api.format(
         'bash -c "./wait_for_elasticsearch.py && ./manage.py makemigrations resources_portal"'
     ),


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/resources-portal/pull/202#discussion_r435452466

## Purpose/Implementation Notes

This makes rportal works no matter what your directory is called.

This also passes arguments through to test from test-api rportal command so it's easy to run just a subset of tests.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests pass!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
