### PR TITLE
Remove autopopulated variables from dev_data

### DIFF
--- a/api/dev_data/attachments.json
+++ b/api/dev_data/attachments.json
@@ -3,38 +3,26 @@
       {
           "filename": "PrimaryLabMTA.pdf",
           "description": "The MTA used by PrimaryLab.",
-          "id": "1",
           "s3_bucket": "bucket-name",
-          "s3_key": "keyname",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "s3_key": "keyname"
       },
       {
           "filename": "RequesterSignedMTA.pdf",
           "description": "The MTA used by PrimaryLab, signed by SecondaryProf.",
-          "id": "2",
           "s3_bucket": "bucket-name",
-          "s3_key": "keyname",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "s3_key": "keyname"
       },
       {
           "filename": "ExecutedMTA.pdf",
           "description": "The MTA used by PrimaryLab, signed by SecondaryProf and PrimProf.",
-          "id": "3",
           "s3_bucket": "bucket-name",
-          "s3_key": "keyname",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "s3_key": "keyname"
       },
       {
           "filename": "SignedIRB.pdf",
           "description": "The signed IRB from SecondaryProf's institution.",
-          "id": "4",
           "s3_bucket": "bucket-name",
-          "s3_key": "keyname",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "s3_key": "keyname"
       }
   ]
 }

--- a/api/dev_data/grants.json
+++ b/api/dev_data/grants.json
@@ -1,132 +1,104 @@
 {
   "grants": [
     {
-      "id": "1",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-30 16:12:25-07",
       "title": "Grant for Research in Melanoma Treatment",
       "funder_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "2",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-30 16:12:25-07",
       "title": "Grant for Research in Tumor Growth",
       "funder_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     }
   ],
   "grants_materials": [
     {
-      "id": "1",
       "grant_id": "1",
       "material_id": "1"
     },
     {
-      "id": "2",
       "grant_id": "1",
       "material_id": "2"
     },
     {
-      "id": "3",
       "grant_id": "1",
       "material_id": "3"
     },
     {
-      "id": "4",
       "grant_id": "1",
       "material_id": "4"
     },
     {
-      "id": "5",
       "grant_id": "2",
       "material_id": "5"
     },
     {
-      "id": "6",
       "grant_id": "2",
       "material_id": "6"
     },
     {
-      "id": "7",
       "grant_id": "2",
       "material_id": "7"
     },
     {
-      "id": "8",
       "grant_id": "2",
       "material_id": "8"
     },
     {
-      "id": "9",
       "grant_id": "2",
       "material_id": "9"
     },
     {
-      "id": "10",
       "grant_id": "2",
       "material_id": "10"
     },
     {
-      "id": "11",
       "grant_id": "2",
       "material_id": "11"
     },
     {
-      "id": "12",
       "grant_id": "2",
       "material_id": "12"
     },
     {
-      "id": "13",
       "grant_id": "2",
       "material_id": "13"
     },
     {
-      "id": "14",
       "grant_id": "2",
       "material_id": "14"
     },
     {
-      "id": "15",
       "grant_id": "2",
       "material_id": "15"
     },
     {
-      "id": "16",
       "grant_id": "2",
       "material_id": "16"
     },
     {
-      "id": "17",
       "grant_id": "2",
       "material_id": "17"
     }
   ],
   "grants_organizations": [
     {
-      "id": "1",
       "grant_id": "1",
       "organization_id": "1"
     },
     {
-      "id": "2",
       "grant_id": "2",
       "organization_id": "4"
     }
   ],
   "grants_users": [
     {
-      "id": "1",
       "grant_id": "1",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "2",
       "grant_id": "2",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "3",
       "grant_id": "2",
       "user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     }

--- a/api/dev_data/materials.json
+++ b/api/dev_data/materials.json
@@ -3,7 +3,6 @@
     {
       "title": "Melanoma Reduction Plasmid",
       "category": "PLASMID",
-      "id": "1",
       "url": "",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -41,12 +40,10 @@
       "pre_print_title": "",
       "citation": "Proffer, Prim. \"Expression Analysis of Zebrafish Melanoma\". March 15, 2020.",
       "additional_info": "",
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": false,
       "needs_abstract": false,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "embargo_date": "2020-01-30",
       "shipping_requirements_id": "1"
@@ -54,7 +51,6 @@
     {
       "title": "Allele Extraction Protocol",
       "category": "PROTOCOL",
-      "id": "2",
       "url": "",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -67,12 +63,10 @@
       "pre_print_title": "",
       "citation": "",
       "additional_info": "This paper was co-authored by Prim Proffer.",
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": false,
       "needs_abstract": true,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "embargo_date": "2020-01-30",
       "shipping_requirements_id": "1"
@@ -80,7 +74,6 @@
     {
       "title": "Zebrafish Model Organism",
       "category": "MODEL_ORGANISM",
-      "id": "3",
       "url": "",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -99,12 +92,10 @@
       "pre_print_title": "",
       "citation": "",
       "additional_info": "",
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": true,
       "needs_abstract": true,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "embargo_date": "2020-01-30",
       "shipping_requirements_id": "1"
@@ -112,7 +103,6 @@
     {
       "title": "Mouse Model Organism",
       "category": "MODEL_ORGANISM",
-      "id": "4",
       "url": "",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -126,12 +116,10 @@
         "construct_details": "The dominant gene is represented in this sample."
       },
       "organism": ["Mus musculus"],
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": false,
       "needs_abstract": true,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "publication_title": "Investigation of expression differences between skin and melanomas from a transgenic BRAFV600E zebrafish model of melanoma",
       "pre_print_doi": "10.1109/5.771073",
@@ -144,7 +132,6 @@
     {
       "title": "Stone Tablet (Other)",
       "category": "OTHER",
-      "id": "5",
       "url": "",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -158,12 +145,10 @@
       "pre_print_title": "The Six and a Half Commandments",
       "citation": "Proffer, Prim. \"The Old Testament\". March 15, 2020.",
       "additional_info": "This tablet was co-authored by Postworth Docktor.",
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": false,
       "needs_abstract": false,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "embargo_date": "2020-01-30",
       "shipping_requirements_id": null
@@ -171,7 +156,6 @@
     {
       "title": "Zebrafish Cell Line",
       "category": "CELL_LINE",
-      "id": "6",
       "url": "",
       "contact_user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
       "organization_id": "4",
@@ -195,12 +179,10 @@
         "passage_number": "21430780"
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": true,
       "needs_abstract": true,
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "publication_title": "",
       "pre_print_doi": "",
@@ -213,7 +195,6 @@
     {
       "title": "Zebrafish Dataset",
       "category": "DATASET",
-      "id": "7",
       "url": "",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -227,12 +208,10 @@
         "platform": "Amazon s3 Database"
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": "1",
       "needs_irb": false,
       "needs_abstract": false,
       "pubmed_id": "",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "publication_title": "",
       "pre_print_doi": "10.1109/5.771073",
@@ -245,7 +224,6 @@
     {
       "title": "Zebrafish PDX",
       "category": "PDX",
-      "id": "8",
       "url": "",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -299,12 +277,10 @@
         "Danio rerio",
         "Mus musculus"
       ],
-      "created_at": "2020-01-30 16:12:25-07",
       "mta_attachment_id": null,
       "needs_irb": true,
       "needs_abstract": true,
       "pubmed_id": "",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": false,
       "publication_title": "Grafting to Zebrafish",
       "pre_print_doi": "10.1109/5.771073",
@@ -317,7 +293,6 @@
     {
       "title": "Imported GEO Dataset",
       "category": "DATASET",
-      "id": "9",
       "url": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE31712",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -331,9 +306,7 @@
         "platform": "Amazon s3 Database"
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Data collected from genetically modified zebrafish",
       "pre_print_doi": "10.1109/5.771073",
@@ -347,7 +320,6 @@
     {
       "title": "Imported SRA Dataset",
       "category": "DATASET",
-      "id": "10",
       "url": "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE37165",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -357,9 +329,7 @@
         "description": "This dataset has interesting implications for future research.",
         "number_samples": "15"
       },
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Data collected from genetically modified zebrafish",
       "pre_print_doi": "10.1109/5.771073",
@@ -373,7 +343,6 @@
     {
       "title": "Imported dbGaP Dataset",
       "category": "DATASET",
-      "id": "11",
       "url": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000328.v2.p1",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -383,9 +352,7 @@
         "description": "This dataset has interesting implications for future research.",
         "number_samples": "15"
       },
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Data collected from genetically modified zebrafish",
       "pre_print_doi": "10.1109/5.771073",
@@ -399,7 +366,6 @@
     {
       "title": "Imported Protocol",
       "category": "PROTOCOL",
-      "id": "12",
       "url": "https://www.protocols.io/view/labyrinthulomycete-dna-extraction-protocol-n83dhyn",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -407,9 +373,7 @@
         "protocol_name": "Extraction of t-type alleles from zebrafish samples",
         "abstract": "A protocol to retrieve t-type alleles relibably and without damage."
       },
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Extraction of t-type alleles from zebrafish samples",
       "pre_print_doi": "10.1109/5.771073",
@@ -423,7 +387,6 @@
     {
       "title": "Imported AddGene Melanoma Reduction Plasmid",
       "category": "PLASMID",
-      "id": "13",
       "url": "https://www.addgene.org/53246/",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -434,9 +397,7 @@
         "relevant_mutations": "Biofloresence"
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Imported Plasmid",
       "pre_print_doi": "10.1109/5.771073",
@@ -450,7 +411,6 @@
     {
       "title": "Jackson Labs Imported Mouse Model Organism",
       "category": "MODEL_ORGANISM",
-      "id": "14",
       "url": "https://www.jax.org/strain/006933",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -459,9 +419,7 @@
         "description": "Investigation of expression differences between skin and melanomas from a transgenic BRAFV600E zebrafish model of melanoma."
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Investigation of expression differences between skin and melanomas from a transgenic BRAFV600E zebrafish model of melanoma",
       "pre_print_doi": "10.1109/5.771073",
@@ -475,7 +433,6 @@
     {
       "title": "ATCC Imported Zebrafish Cell Line",
       "category": "CELL_LINE",
-      "id": "15",
       "url": "https://www.atcc.org/products/all/CCL-185.aspx#generalinformation",
       "contact_user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
       "organization_id": "4",
@@ -490,9 +447,7 @@
         "ethnicity": "N/A"
       },
       "organism": ["Danio rerio"],
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Cell Line from Zebrafish Sample",
       "pre_print_doi": "10.1109/5.771073",
@@ -506,7 +461,6 @@
     {
       "title": "ZIRC Imported Zebrafish Model Organism",
       "category": "MODEL_ORGANISM",
-      "id": "16",
       "url": "http://zfin.org/ZDB-GENO-100413-1",
       "contact_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "organization_id": "1",
@@ -517,9 +471,7 @@
         "genotype": "TTdDsS"
       },
       "organism": ["Mus musculus"],
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "Investigation of expression differences between skin and melanomas from a transgenic BRAFV600E zebrafish model of melanoma",
       "pre_print_doi": "10.1109/5.771073",
@@ -533,7 +485,6 @@
     {
       "title": "Imported Stone Tablet (Other)",
       "category": "OTHER",
-      "id": "17",
       "url": "https://www.ncbi.nlm.nih.gov/pubmed/32223680",
       "contact_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "organization_id": "1",
@@ -542,9 +493,7 @@
         "title": "The Ten Commandments",
         "description": "Given to me by an old man who said to \"Let my research go\". He then parted my hair by raising his staff and left."
       },
-      "created_at": "2020-01-30 16:12:25-07",
       "pubmed_id": "32223680",
-      "updated_at": "2020-01-30 16:12:25-07",
       "imported": true,
       "publication_title": "The Ten Commandments",
       "pre_print_doi": "10.1109/5.771073",
@@ -558,9 +507,6 @@
   ],
   "materials_requests": [
     {
-      "id": "1",
-      "created_at": "2020-01-30 14:12:25-07",
-      "updated_at": "2020-01-30 14:12:25-07",
       "requester_signed_mta_attachment_id": "2",
       "executed_mta_attachment_id": "3",
       "irb_attachment_id": "4",
@@ -573,9 +519,6 @@
   ],
   "materials_share_events": [
     {
-      "id": "1",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-01-30 16:12:25-07",
       "event_type": "shared",
       "time": "2020-01-30 16:12:25-07",
       "assigned_to_id": "20000000-a55d-42b7-b53e-056956e18b8c",

--- a/api/dev_data/notifications.json
+++ b/api/dev_data/notifications.json
@@ -1,54 +1,44 @@
 {
     "notifications": [
         {
-            "id": "1",
             "notification_type": "ORG_REQUEST_CREATED",
             "notified_user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
             "associated_organization_id": "4",
             "associated_material_id": "",
             "associated_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-            "email": "burt_reynolds@mustache.com",
-            "created_at": "2020-01-30 16:12:25-07"
+            "email": "burt_reynolds@mustache.com"
         },
         {
-            "id": "2",
             "notification_type": "ORG_REQUEST_ACCEPTED",
             "notified_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
             "associated_organization_id": "1",
             "associated_material_id": "",
             "associated_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-            "email": "mjmoonman@heehee.org",
-            "created_at": "2020-01-30 16:12:25-07"
+            "email": "mjmoonman@heehee.org"
         },
         {
-            "id": "3",
             "notification_type": "TRANSFER_REQUESTED",
             "notified_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
             "associated_organization_id": "1",
             "associated_material_id": "2",
             "associated_user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-            "email": "jasonstatham@chasingbacon.org",
-            "created_at": "2020-01-30 16:12:25-07"
+            "email": "jasonstatham@chasingbacon.org"
         },
         {
-            "id": "4",
             "notification_type": "APPROVE_REQUESTS_PERM_GRANTED",
             "notified_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
             "associated_organization_id": "1",
             "associated_material_id": "",
             "associated_user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-            "email": "paulastartes@spiceitup.com",
-            "created_at": "2020-01-30 16:12:25-07"
+            "email": "paulastartes@spiceitup.com"
         },
         {
-            "id": "5",
             "notification_type": "MTA_UPLOADED",
             "notified_user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
             "associated_organization_id": "1",
             "associated_material_id": "2",
             "associated_user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
-            "email": "geraltwitcher@cointoss.com",
-            "created_at": "2020-01-30 16:12:25-07"
+            "email": "geraltwitcher@cointoss.com"
         }
     ]
 }

--- a/api/dev_data/organizations.json
+++ b/api/dev_data/organizations.json
@@ -2,100 +2,71 @@
   "organizations": [
     {
       "name": "PrimaryLab",
-      "id": "1",
-      "owner_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-21 10:11:25-07"
+      "owner_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
       "name": "PrimaryProfPersonalOrg",
-      "id": "2",
-      "owner_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-      "created_at": "2020-02-13 18:12:25-07",
-      "updated_at": "2020-02-10 10:12:25-07"
+      "owner_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
       "name": "PostDocOrg",
-      "id": "3",
-      "owner_id": "20000000-a55d-42b7-b53e-056956e18b8c",
-      "created_at": "2020-01-02 15:02:25-07",
-      "updated_at": "2020-03-24 10:12:25-07"
+      "owner_id": "20000000-a55d-42b7-b53e-056956e18b8c"
     },
     {
       "name": "SecondaryProfOrg",
-      "id": "4",
-      "owner_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "created_at": "2020-03-27 09:12:25-07",
-      "updated_at": "2020-03-29 11:13:25-07"
+      "owner_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     }
   ],
   "organizations_members": [
     {
-      "id": "1",
       "organization_id": "1",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "2",
       "organization_id": "2",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "3",
       "organization_id": "1",
       "user_id": "20000000-a55d-42b7-b53e-056956e18b8c"
     },
     {
-      "id": "4",
       "organization_id": "3",
       "user_id": "20000000-a55d-42b7-b53e-056956e18b8c"
     },
     {
-      "id": "5",
       "organization_id": "4",
       "user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     }
   ],
   "organization_invitations": [
     {
-      "id": "1",
       "organization_id": "4",
       "status": "PENDING",
       "invite_or_request": "INVITE",
       "request_reciever_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "requester_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-21 10:11:25-07"
+      "requester_id": "10000000-0f5a-4165-b518-b2386a753d6f"
     },
     {
-      "id": "2",
       "organization_id": "3",
       "status": "ACCEPTED",
       "invite_or_request": "INVITE",
       "request_reciever_id": "20000000-a55d-42b7-b53e-056956e18b8c",
-      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-21 10:11:25-07"
+      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     },
     {
-      "id": "3",
       "organization_id": "1",
       "status": "REJECTED",
       "invite_or_request": "INVITE",
       "request_reciever_id": "10000000-0f5a-4165-b518-b2386a753d6f",
-      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-21 10:11:25-07"
+      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     },
     {
-      "id": "4",
       "organization_id": "1",
       "status": "INVALID",
       "invite_or_request": "INVITE",
       "request_reciever_id": "20000000-a55d-42b7-b53e-056956e18b8c",
-      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-03-21 10:11:25-07"
+      "requester_id": "30000000-231f-4dc8-bbfa-02bccfb0372c"
     }
   ]
 }

--- a/api/dev_data/shipping_requirements.json
+++ b/api/dev_data/shipping_requirements.json
@@ -1,26 +1,20 @@
 {
   "shipping_requirements": [
       {
-          "id": "1",
           "needs_shipping_address": true,
           "needs_payment": true,
           "accepts_shipping_code": true,
           "accepts_reimbursement": false,
           "accepts_other_payment_methods": false,
-          "restrictions": "Only ships within the greater Hanover area.",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "restrictions": "Only ships within the greater Hanover area."
       },
       {
-          "id": "2",
           "needs_shipping_address": true,
           "needs_payment": false,
           "accepts_shipping_code": false,
           "accepts_reimbursement": false,
           "accepts_other_payment_methods": false,
-          "restrictions": "None. Free yourself!",
-          "created_at": "2020-01-30 16:12:25-07",
-          "updated_at": "2020-01-30 16:12:25-07"
+          "restrictions": "None. Free yourself!"
       }
   ]
 }

--- a/api/dev_data/users.json
+++ b/api/dev_data/users.json
@@ -13,9 +13,7 @@
       "is_active": "True",
       "date_joined": "2020-01-22 19:10:25-07",
       "id": "10000000-0f5a-4165-b518-b2386a753d6f",
-      "orcid": "0000-0001-2345-6789",
-      "created_at": "2020-01-01 16:15:25-07",
-      "updated_at": "2020-01-01 16:15:25-07"
+      "orcid": "0000-0001-2345-6789"
     },
     {
       "username": "PostDoc",
@@ -30,9 +28,7 @@
       "is_active": "True",
       "date_joined": "2020-01-01 16:15:25-07",
       "id": "20000000-a55d-42b7-b53e-056956e18b8c",
-      "orcid": "1000-0001-2345-6789",
-      "created_at": "2020-01-01 16:15:25-07",
-      "updated_at": "2020-01-01 16:15:25-07"
+      "orcid": "1000-0001-2345-6789"
     },
     {
       "username": "SecondaryProf",
@@ -47,88 +43,68 @@
       "is_active": "True",
       "date_joined": "2020-03-26 04:12:25-07",
       "id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
-      "orcid": "2000-0001-2345-6789",
-      "created_at": "2020-01-01 16:15:25-07",
-      "updated_at": "2020-01-01 16:15:25-07"
+      "orcid": "2000-0001-2345-6789"
     }
   ],
   "resources_portal_user_groups": [
     {
-      "id": "1",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "group_id": "2"
     },
     {
-      "id": "2",
       "user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "group_id": "2"
     },
     {
-      "id": "3",
       "user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
       "group_id": "2"
     }
   ],
   "organization_user_setting": [
     {
-      "id": "1",
       "organization_id": "1",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "new_request_notif": "True",
       "change_in_request_status_notif": "False",
       "request_approval_determined_notif": "False",
       "request_assigned_notif": "False",
-      "reminder_notif": "False",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-01-30 16:12:25-07"
+      "reminder_notif": "False"
     },
     {
-      "id": "1",
       "organization_id": "2",
       "user_id": "10000000-0f5a-4165-b518-b2386a753d6f",
       "new_request_notif": "True",
       "change_in_request_status_notif": "True",
       "request_approval_determined_notif": "True",
       "request_assigned_notif": "True",
-      "reminder_notif": "True",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-01-30 16:12:25-07"
+      "reminder_notif": "True"
     },
     {
-      "id": "2",
       "organization_id": "1",
       "user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "new_request_notif": "True",
       "change_in_request_status_notif": "True",
       "request_approval_determined_notif": "True",
       "request_assigned_notif": "True",
-      "reminder_notif": "True",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-01-30 16:12:25-07"
+      "reminder_notif": "True"
     },
     {
-      "id": "3",
       "organization_id": "3",
       "user_id": "20000000-a55d-42b7-b53e-056956e18b8c",
       "new_request_notif": "True",
       "change_in_request_status_notif": "True",
       "request_approval_determined_notif": "True",
       "request_assigned_notif": "True",
-      "reminder_notif": "False",
-      "created_at": "2020-01-30 16:12:25-07",
-      "updated_at": "2020-01-30 16:12:25-07"
+      "reminder_notif": "False"
     },
     {
-      "id": "4",
       "organization_id": "4",
       "user_id": "30000000-231f-4dc8-bbfa-02bccfb0372c",
       "new_request_notif": "True",
       "change_in_request_status_notif": "True",
       "request_approval_determined_notif": "True",
       "request_assigned_notif": "True",
-      "reminder_notif": "True",
-      "created_at": "2020-03-30 16:12:25-07",
-      "updated_at": "2020-03-30 16:12:25-07"
+      "reminder_notif": "True"
     }
   ]
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This PR reomves autopopuated variables from dev_data. The sequence that keeps track of what ID should be assigned to the next object doesn't count entries where ID is provided, which messes up future objects added with POST because it will try to insert an object with a pre-existing ID. 

I also removed created_at and updated_at because they're unneccessary.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran `rportal populate-db` , ensured that it inserts objects in the same way as before by verifying on the database.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
