### PR TITLE
Updated nav menu for docs

### DIFF
--- a/api/resources_portal/views/attachment.py
+++ b/api/resources_portal/views/attachment.py
@@ -17,7 +17,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
             "description",
             "s3_bucket",
             "s3_key",
-            "deleted",
+            "s3_resource_deleted",
             "created_at",
             "updated_at",
             "sequence_map_for",

--- a/api/resources_portal/views/material_request.py
+++ b/api/resources_portal/views/material_request.py
@@ -35,7 +35,6 @@ class MaterialRequestSerializer(serializers.ModelSerializer):
             "id",
             "created_at",
             "updated_at",
-            "material",
             "assigned_to",
             "requester",
         )

--- a/api/resources_portal/views/material_request.py
+++ b/api/resources_portal/views/material_request.py
@@ -31,7 +31,14 @@ class MaterialRequestSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         )
-        read_only_fields = ("id", "created_at", "updated_at")
+        read_only_fields = (
+            "id",
+            "created_at",
+            "updated_at",
+            "material",
+            "assigned_to",
+            "requester",
+        )
 
 
 class MaterialRequestDetailSerializer(MaterialRequestSerializer):
@@ -149,6 +156,8 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         material = serializer.validated_data["material"]
+
+        serializer.validated_data["requester"] = request.user
 
         material_request = MaterialRequest(**serializer.validated_data)
         material_request.save()

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -16,7 +16,7 @@ Name            | Type   | Description
 ----------------|--------|---
 filename        | string | The filename of the attachment.
 description     | string | A description of the attachment.
-s3_bucket       | string | The url of the s3_bucket where your attachment file is stored.
+s3_bucket       | string | The bucket name if the attachment file.
 s3_key          | string | The key of your s3 object.
 sequence_map_for| json   | A material object in json. The material which this attachment is a sequence map for.
 
@@ -35,9 +35,9 @@ Content-Type application/json
    "id":18,
    "filename":"attachment_file",
    "description":"A file for testing",
-   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
-   "s3_key":"s3 key",
-   "deleted":"None",
+   "s3_bucket":"bucket-name",
+   "s3_key":"keyname",
+   "s3_resource_deleted":false,
    "created_at":"2020-07-01T16:53:13+0000",
    "updated_at":"2020-07-01T16:53:13+0000",
    "sequence_map_for":"None"
@@ -68,9 +68,9 @@ Content-Type application/json
    "id":21,
    "filename":"attachment_file",
    "description":"A file for testing",
-   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
-   "s3_key":"s3 key",
-   "deleted":"None",
+   "s3_bucket":"bucket-name",
+   "s3_key":"keyname",
+   "s3_resource_deleted":false,
    "created_at":"2020-07-01T17:09:17+0000",
    "updated_at":"2020-07-01T17:09:17+0000",
    "sequence_map_for":"None"
@@ -94,19 +94,19 @@ Content-Type application/json
 Content-Type application/json
 200 OK
 
-...
+[
    {
       "id":21,
       "filename":"attachment_file",
       "description":"A file for testing",
-      "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
-      "s3_key":"s3 key",
-      "deleted":"None",
+      "s3_bucket":"bucket-name",
+      "s3_key":"keyname",
+      "s3_resource_deleted":false,
       "created_at":"2020-07-01T17:09:17+0000",
       "updated_at":"2020-07-01T17:09:17+0000",
       "sequence_map_for":"None"
    }
-...
+]
 
 ```
 
@@ -122,7 +122,7 @@ Name            | Type   | Description
 ----------------|--------|---
 filename        | string | The filename of the attachment.
 description     | string | A description of the attachment.
-s3_bucket       | string | The url of the s3_bucket where your attachment file is stored.
+s3_bucket       | string | The bucket name if the attachment file.
 s3_key          | string | The key of your s3 object.
 sequence_map_for| json   | A material object in json, the material which this attachment is a sequence map for.
 
@@ -145,9 +145,9 @@ Content-Type application/json
    "id":21,
    "filename":"attachment_file",
    "description":"A file for testing",
-   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
-   "s3_key":"s3 key",
-   "deleted":"None",
+   "s3_bucket":"bucket-name",
+   "s3_key":"keyname",
+   "s3_resource_deleted":false,
    "created_at":"2020-07-01T17:09:17+0000",
    "updated_at":"2020-07-01T17:09:17+0000",
    "sequence_map_for":"None"

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -1,6 +1,9 @@
 # Attachments
 Supports adding, viewing, deleting, and updating attachments.
 
+## Description
+Attachments are used to support any kind of external file. These are often PDFs or images. Attachments are used for Material Transfer Agreements, Institutional Review Board documents, and sequence maps for materials among other things.
+
 ## Add a new attachment:
 
 **Request**:

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -1,0 +1,173 @@
+# Attachments
+Supports adding, viewing, deleting, and updating attachments.
+
+## Add a new attachment:
+
+**Request**:
+
+`POST` `/attachments/`
+
+Parameters:
+
+Name            | Type   | Description
+----------------|--------|---
+filename        | string | The filename of the attachment.
+description     | string | A description of the attachment.
+s3_bucket       | string | The url of the s3_bucket where your attachment file is stored.
+s3_key          | string | The key of your s3 object.
+sequence_map_for| json   | A material object in json, the material which this attachment is a sequence map for.
+
+*Note:*
+
+- `sequence_map_for` is optional, and should only be provided when the attachment is a sequence map.
+- **[Authorization Protected](authentication.md)**
+
+**Response**:
+
+```json
+Content-Type application/json
+201 CREATED
+
+{
+   "id":18,
+   "filename":"attachment_file",
+   "description":"A file for testing",
+   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
+   "s3_key":"s3 key",
+   "deleted":"None",
+   "created_at":"2020-07-01T16:53:13+0000",
+   "updated_at":"2020-07-01T16:53:13+0000",
+   "sequence_map_for":"None"
+}
+```
+
+## Get information on an attachment:
+
+**Request**:
+
+`GET` `/attachments/:id`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- The only users who can view an attachment are:
+1. Users who are part of an organization which has an active material request
+2. Users who are the `requester` on an active material request
+3. Admins
+
+**Response**:
+
+```json
+Content-Type application/json
+200 OK
+
+{
+   "id":21,
+   "filename":"attachment_file",
+   "description":"A file for testing",
+   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
+   "s3_key":"s3 key",
+   "deleted":"None",
+   "created_at":"2020-07-01T17:09:17+0000",
+   "updated_at":"2020-07-01T17:09:17+0000",
+   "sequence_map_for":"None"
+}
+```
+
+## List attachments:
+
+**Request**:
+
+`GET` `/attachments/`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- Only admins can list attachments.
+
+**Response**:
+
+```json
+Content-Type application/json
+200 OK
+{
+...
+   {
+      "id":21,
+      "filename":"attachment_file",
+      "description":"A file for testing",
+      "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
+      "s3_key":"s3 key",
+      "deleted":"None",
+      "created_at":"2020-07-01T17:09:17+0000",
+      "updated_at":"2020-07-01T17:09:17+0000",
+      "sequence_map_for":"None"
+   }
+...
+}
+```
+
+## Update an attachment
+
+**Request**:
+
+`PUT/PATCH` `/attachments/:id`
+
+Parameters:
+
+Name            | Type   | Description
+----------------|--------|---
+filename        | string | The filename of the attachment.
+description     | string | A description of the attachment.
+s3_bucket       | string | The url of the s3_bucket where your attachment file is stored.
+s3_key          | string | The key of your s3 object.
+sequence_map_for| json   | A material object in json, the material which this attachment is a sequence map for.
+
+*Note:*
+
+- All parameters are optional
+- **[Authorization Protected](authentication.md)**
+- The only users who can update an attachment are:
+1. Users who are part of an organization which has an active material request
+2. Users who are the `requester` on an active material request
+3. Admins
+
+**Response**:
+
+```json
+Content-Type application/json
+200 OK
+
+{
+   "id":21,
+   "filename":"attachment_file",
+   "description":"A file for testing",
+   "s3_bucket":"https://bucket-name.s3.region.amazonaws.com/keyname",
+   "s3_key":"s3 key",
+   "deleted":"None",
+   "created_at":"2020-07-01T17:09:17+0000",
+   "updated_at":"2020-07-01T17:09:17+0000",
+   "sequence_map_for":"None"
+}
+```
+
+## Delete an attachment
+
+**Request**:
+
+`DELETE` `/attachments/:id`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- The only users who can delete an attachment are:
+1. Users who are part of an organization which has an active material request
+2. Users who are the `requester` on an active material request
+3. Admins
+
+**Response**:
+
+```json
+Content-Type application/json
+204 NO_CONTENT
+```

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -15,7 +15,7 @@ filename        | string | The filename of the attachment.
 description     | string | A description of the attachment.
 s3_bucket       | string | The url of the s3_bucket where your attachment file is stored.
 s3_key          | string | The key of your s3 object.
-sequence_map_for| json   | A material object in json, the material which this attachment is a sequence map for.
+sequence_map_for| json   | A material object in json. The material which this attachment is a sequence map for.
 
 *Note:*
 
@@ -51,9 +51,9 @@ Content-Type application/json
 
 - **[Authorization Protected](authentication.md)**
 - The only users who can view an attachment are:
-1. Users who are part of an organization which has an active material request
-2. Users who are the `requester` on an active material request
-3. Admins
+   1. Users who are part of an organization which has an active material request
+   2. Users who are the `requester` on an active material request
+   3. Admins
 
 **Response**:
 
@@ -90,7 +90,7 @@ Content-Type application/json
 ```json
 Content-Type application/json
 200 OK
-{
+
 ...
    {
       "id":21,
@@ -104,7 +104,7 @@ Content-Type application/json
       "sequence_map_for":"None"
    }
 ...
-}
+
 ```
 
 ## Update an attachment
@@ -128,9 +128,9 @@ sequence_map_for| json   | A material object in json, the material which this at
 - All parameters are optional
 - **[Authorization Protected](authentication.md)**
 - The only users who can update an attachment are:
-1. Users who are part of an organization which has an active material request
-2. Users who are the `requester` on an active material request
-3. Admins
+   1. Users who are part of an organization which has an active material request
+   2. Users who are the `requester` on an active material request
+   3. Admins
 
 **Response**:
 
@@ -161,9 +161,9 @@ Content-Type application/json
 
 - **[Authorization Protected](authentication.md)**
 - The only users who can delete an attachment are:
-1. Users who are part of an organization which has an active material request
-2. Users who are the `requester` on an active material request
-3. Admins
+   1. Users who are part of an organization which has an active material request
+   2. Users who are the `requester` on an active material request
+   3. Admins
 
 **Response**:
 

--- a/docs/api/attachments.md
+++ b/docs/api/attachments.md
@@ -16,7 +16,7 @@ Name            | Type   | Description
 ----------------|--------|---
 filename        | string | The filename of the attachment.
 description     | string | A description of the attachment.
-s3_bucket       | string | The bucket name if the attachment file.
+s3_bucket       | string | The bucket name of the attachment file.
 s3_key          | string | The key of your s3 object.
 sequence_map_for| json   | A material object in json. The material which this attachment is a sequence map for.
 
@@ -122,7 +122,7 @@ Name            | Type   | Description
 ----------------|--------|---
 filename        | string | The filename of the attachment.
 description     | string | A description of the attachment.
-s3_bucket       | string | The bucket name if the attachment file.
+s3_bucket       | string | The bucket name of the attachment file.
 s3_key          | string | The key of your s3 object.
 sequence_map_for| json   | A material object in json, the material which this attachment is a sequence map for.
 

--- a/docs/api/grants.md
+++ b/docs/api/grants.md
@@ -18,6 +18,8 @@ funder_id  | string | Alex's Lemonade Stand Foundation or third-party grant id.
 
 - **[Authorization Protected](authentication.md)**
 
+**Response**:
+
 ```json
 Content-Type application/json
 200 OK
@@ -50,6 +52,8 @@ Content-Type application/json
 
 - **[Authorization Protected](authentication.md)**
 - Only the owner of a grant can get its information.
+
+**Response**:
 
 ```json
 Content-Type application/json
@@ -121,6 +125,8 @@ funder_id  | string | Alex's Lemonade Stand Foundation or third-party grant id.
 - **[Authorization Protected](authentication.md)**
 - Only the owner of a grant can update it.
 
+**Response**:
+
 ```json
 Content-Type application/json
 200 OK
@@ -182,6 +188,8 @@ Content-Type application/json
 
 - **[Authorization Protected](authentication.md)**
 - Only the owner of a grant can view the materials.
+
+**Response**:
 
 ```json
 Content-Type application/json

--- a/docs/api/grants.md
+++ b/docs/api/grants.md
@@ -1,6 +1,9 @@
 # Grants
 Supports adding, viewing, and updating grants. Contains nested routes for associated materials.
 
+## Description
+The Grant object represents ALSF grants associated with users or organizations.
+
 ## Register a new user account
 
 **Request**:

--- a/docs/api/material_requests.md
+++ b/docs/api/material_requests.md
@@ -1,5 +1,8 @@
 # Material Requests
-Supports adding, viewing, deleting, and updating attachments.
+Supports adding, viewing, deleting, and updating material requests.
+
+## Description
+Material Requests are used to track the progress of a material trasfer between a requester and the organization in charge of the requested material. All documents associated with the transfer are linked to the Material Request object.
 
 ## Add a new material request:
 

--- a/docs/api/material_requests.md
+++ b/docs/api/material_requests.md
@@ -1,0 +1,171 @@
+# Material Requests
+Supports adding, viewing, deleting, and updating attachments.
+
+## Add a new material request:
+
+**Request**:
+
+`POST` `/material-requests/`
+
+Parameters:
+
+Name                           | Type   | Description
+-------------------------------|--------|---
+material                       | int    | The ID of the material being requested.
+requester_signed_mta_attachment| int    | The ID of an attachment object which references a signed Material Transfer Agreement attachment.
+irb_attachment                 | int    | The ID of an attachment object which references an Institutional Review Board attachment.
+
+
+*Note:*
+
+- `sequence_map_for` is optional, and should only be provided when the attachment is a sequence map.
+- **[Authorization Protected](authentication.md)**
+
+**Response**:
+
+```json
+Content-Type application/json
+201 CREATED
+
+{
+   "id":6,
+   "material":5,
+   "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
+   "requester_signed_mta_attachment":15,
+   "irb_attachment":14,
+   "executed_mta_attachment":13,
+   "is_active":True,
+   "status":"PENDING",
+   "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
+}
+```
+
+## Get information on a material request
+
+**Request**:
+
+`GET` `/material-requests/:id`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- The only users who can view a material requests are:
+1. Users who are part of the organization which owns the requested material
+2. The requester
+
+**Response**:
+
+```
+json
+Content-Type application/json
+200 OK
+
+{
+   "id":6,
+   "material":5,
+   "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
+   "requester_signed_mta_attachment":15,
+   "irb_attachment":14,
+   "executed_mta_attachment":13,
+   "is_active":True,
+   "status":"PENDING",
+   "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
+}
+```
+
+## List material requests:
+
+**Request**:
+
+`GET` `/material-requests/`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- The only users who can list material requests are:
+1. Users who are part of the organization which owns the requested material
+
+**Response**:
+
+```
+json
+Content-Type application/json
+200 OK
+{
+...
+    {
+    "id":6,
+    "material":5,
+    "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
+    "requester_signed_mta_attachment":15,
+    "irb_attachment":14,
+    "executed_mta_attachment":13,
+    "is_active":True,
+    "status":"PENDING",
+    "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
+    }
+...
+}
+```
+
+## Update a material request
+
+**Request**:
+
+`PUT/PATCH` `/material-requests/:id`
+
+Parameters:
+
+Name                           | Type   | Description
+-------------------------------|--------|---
+status                         | string | The current status of the material request. Updating this will send notifications to the other party in the material request.
+requester_signed_mta_attachment| int    | The ID of an attachment object which references a signed Material Transfer Agreement attachment.
+irb_attachment                 | int    | The ID of an attachment object which references an Institutional Review Board attachment.
+executed_mta_attachment        | int    | The ID of an attachment object which references an executed MTA attachment.
+is_active                      | bool   | Boolean determining if the material request has been resolved or not.
+
+*Note:*
+
+- All parameters are optional
+- **[Authorization Protected](authentication.md)**
+- The only users who can update an attachment are:
+1. Users who are part of an organization which has an active material request
+2. The requester
+
+**Response**:
+
+```
+json
+Content-Type application/json
+200 OK
+
+{
+   "id":6,
+   "material":5,
+   "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
+   "requester_signed_mta_attachment":15,
+   "irb_attachment":14,
+   "executed_mta_attachment":13,
+   "is_active":True,
+   "status":"PENDING",
+   "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
+}
+```
+
+## Delete an attachment
+
+**Request**:
+
+`DELETE` `/material-requests/:id`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- Only admins can delete a material request.
+
+**Response**:
+
+```json
+Content-Type application/json
+204 NO_CONTENT
+```

--- a/docs/api/material_requests.md
+++ b/docs/api/material_requests.md
@@ -21,8 +21,8 @@ irb_attachment                 | int    | The ID of an attachment object which r
 
 *Note:*
 
-- `sequence_map_for` is optional, and should only be provided when the attachment is a sequence map.
 - **[Authorization Protected](authentication.md)**
+- `requester_signed_mta_attachment` and `irb_attachment` are optional, and can be populated later in a PUT/PATCH.
 
 **Response**:
 
@@ -34,9 +34,9 @@ Content-Type application/json
    "id":6,
    "material":5,
    "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
-   "requester_signed_mta_attachment":15,
-   "irb_attachment":14,
-   "executed_mta_attachment":13,
+   "requester_signed_mta_attachment":"None",
+   "irb_attachment":"None",
+   "executed_mta_attachment":"None",
    "is_active":true,
    "status":"PENDING",
    "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
@@ -91,21 +91,19 @@ Content-Type application/json
 ```json
 Content-Type application/json
 200 OK
-
-...
-    {
-    "id":6,
-    "material":5,
-    "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
-    "requester_signed_mta_attachment":15,
-    "irb_attachment":14,
-    "executed_mta_attachment":13,
-    "is_active":true,
-    "status":"PENDING",
-    "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
-    }
-...
-
+[
+      {
+      "id":6,
+      "material":5,
+      "requester":"ee1d43f8-7407-4031-9f1b-f9a5fcf2da26",
+      "requester_signed_mta_attachment":15,
+      "irb_attachment":14,
+      "executed_mta_attachment":13,
+      "is_active":true,
+      "status":"PENDING",
+      "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
+      }
+]
 ```
 
 ## Update a material request

--- a/docs/api/material_requests.md
+++ b/docs/api/material_requests.md
@@ -34,7 +34,7 @@ Content-Type application/json
    "requester_signed_mta_attachment":15,
    "irb_attachment":14,
    "executed_mta_attachment":13,
-   "is_active":True,
+   "is_active":true,
    "status":"PENDING",
    "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
 }
@@ -50,13 +50,12 @@ Content-Type application/json
 
 - **[Authorization Protected](authentication.md)**
 - The only users who can view a material requests are:
-1. Users who are part of the organization which owns the requested material
-2. The requester
+   1. Users who are part of the organization which owns the requested material
+   2. The requester
 
 **Response**:
 
-```
-json
+```json
 Content-Type application/json
 200 OK
 
@@ -67,7 +66,7 @@ Content-Type application/json
    "requester_signed_mta_attachment":15,
    "irb_attachment":14,
    "executed_mta_attachment":13,
-   "is_active":True,
+   "is_active":true,
    "status":"PENDING",
    "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
 }
@@ -82,16 +81,14 @@ Content-Type application/json
 *Note:*
 
 - **[Authorization Protected](authentication.md)**
-- The only users who can list material requests are:
-1. Users who are part of the organization which owns the requested material
+- The only users who can list material requests are users who are part of the organization which owns the requested material.
 
 **Response**:
 
-```
-json
+```json
 Content-Type application/json
 200 OK
-{
+
 ...
     {
     "id":6,
@@ -100,12 +97,12 @@ Content-Type application/json
     "requester_signed_mta_attachment":15,
     "irb_attachment":14,
     "executed_mta_attachment":13,
-    "is_active":True,
+    "is_active":true,
     "status":"PENDING",
     "assigned_to":"f75bd715-e188-4c4e-80a3-623793770730"
     }
 ...
-}
+
 ```
 
 ## Update a material request
@@ -129,8 +126,8 @@ is_active                      | bool   | Boolean determining if the material re
 - All parameters are optional
 - **[Authorization Protected](authentication.md)**
 - The only users who can update an attachment are:
-1. Users who are part of an organization which has an active material request
-2. The requester
+   1. Users who are part of an organization which has an active material request
+   2. The requester
 
 **Response**:
 

--- a/docs/api/materials.md
+++ b/docs/api/materials.md
@@ -130,6 +130,8 @@ shipping_requirements_id | integer   | The ID of the shipping requerements. Null
 - All parameters are optional
 - Not Authorization Protected
 
+**Response**:
+
 ```json
 Content-Type application/json
 200 OK

--- a/docs/api/materials.md
+++ b/docs/api/materials.md
@@ -1,6 +1,9 @@
 # Materials
 Supports creating, viewing, and updating materials.
 
+## Description
+Materials are used to represent any transferrable piece of research listed on the site. They contain metadata about the information or scientific resource which they represent.
+
 ## Add a new material
 
 **Request**:

--- a/docs/api/organizations.md
+++ b/docs/api/organizations.md
@@ -77,6 +77,8 @@ members    | list(string) | Yes      | A list of the IDs of members of the organ
 - All parameters are optional
 - Not Authorization Protected
 
+**Response**:
+
 ```json
 Content-Type application/json
 200 OK

--- a/docs/api/organizations.md
+++ b/docs/api/organizations.md
@@ -1,6 +1,9 @@
 # Organizations
 Supports creating, viewing, and updating organizations and their members.
 
+## Description
+An organization is used to keep track of the members of any scientic group, the materials that they have produced, and their grants.
+
 ## Create a new organization
 
 **Request**:

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -12,7 +12,7 @@ Searches can be performed by adding ```?:search_parameter``` onto the search req
 
 Filtering can narrow down your search results. To filter, specify the name of your filterable field and a value to filter on. For example, to filter your search to dataset materials only, your request would be:
 ```search/materials?category=DATASET```
-A list of all filterable fields for a given search will be returned with the search results, under the "facets" field, in the follwing format:
+A list of all filterable fields for a given search will be returned with the search results, under the "facets" field, in the following format:
 ```json
 "facets": {
     "has_publication": {

--- a/docs/api/user_settings.md
+++ b/docs/api/user_settings.md
@@ -17,11 +17,11 @@ Content-Type application/json
 
 {
    "id":8,
-   "new_request_notif":True,
-   "change_in_request_status_notif":True,
-   "request_approval_determined_notif":True,
-   "request_assigned_notif":True,
-   "reminder_notif":True,
+   "new_request_notif":true,
+   "change_in_request_status_notif":true,
+   "request_approval_determined_notif":true,
+   "request_assigned_notif":true,
+   "reminder_notif":true,
    "user":"UUID("   "8adbfcf0-7b4e-45b7-811a-f63a44d63c3d"   ")",
    "organization":3,
    "created_at":"2020-07-01T19:52:07+0000",

--- a/docs/api/user_settings.md
+++ b/docs/api/user_settings.md
@@ -1,0 +1,72 @@
+## Get information on a user's settings:
+
+**Request**:
+
+`GET` `/organization-user-settings/:id`
+
+*Note:*
+
+- **[Authorization Protected](authentication.md)**
+- Only the user referenced by a settings object can view it. They also can only view settings while they are still in the organization referenced by the settings object.
+
+**Response**:
+
+```json
+Content-Type application/json
+200 OK
+
+{
+   "id":8,
+   "new_request_notif":True,
+   "change_in_request_status_notif":True,
+   "request_approval_determined_notif":True,
+   "request_assigned_notif":True,
+   "reminder_notif":True,
+   "user":"UUID("   "8adbfcf0-7b4e-45b7-811a-f63a44d63c3d"   ")",
+   "organization":3,
+   "created_at":"2020-07-01T19:52:07+0000",
+   "updated_at":"2020-07-01T19:52:07+0000"
+}
+```
+
+## Update an attachment
+
+**Request**:
+
+`PUT/PATCH` `/organization-user-settings/:id`
+
+Parameters:
+
+Name                             | Type | Description
+---------------------------------|------|---
+new_request_notif                | bool | Specifies whether the user will recieve notifications of new requests from the assocoiated organization.
+change_in_request_status_notif   | bool | Specifies whether the user will recieve notifications of changes in requests from the assocoiated organization.
+request_approval_determined_notif| bool | Specifies whether the user will recieve notifications when requests are approved/denied.
+request_assigned_notif           | bool | Specifies whether the user will recieve notifications when a new request is assigned to them.
+reminder_notif                   | bool | Specifies whether the user will recieve notifications reminding them of outstanding requirements.
+
+*Note:*
+
+- All parameters are optional
+- **[Authorization Protected](authentication.md)**
+- Only the user referenced by a settings object can update it. They also can only update settings while they are still in the organization referenced by the settings object.
+
+**Response**:
+
+```json
+Content-Type application/json
+200 OK
+
+{
+   "id":8,
+   "new_request_notif":True,
+   "change_in_request_status_notif":True,
+   "request_approval_determined_notif":True,
+   "request_assigned_notif":True,
+   "reminder_notif":True,
+   "user":"UUID("   "8adbfcf0-7b4e-45b7-811a-f63a44d63c3d"   ")",
+   "organization":3,
+   "created_at":"2020-07-01T19:52:07+0000",
+   "updated_at":"2020-07-01T19:52:07+0000"
+}
+```

--- a/docs/api/user_settings.md
+++ b/docs/api/user_settings.md
@@ -1,3 +1,9 @@
+# User Settings
+Supports viewing and updating user settings.
+
+## Description
+User settings determine what notifications a user will recieve. They can toggle each of a number of categories of notifications on or off.
+
 ## Get information on a user's settings:
 
 **Request**:

--- a/docs/api/user_settings.md
+++ b/docs/api/user_settings.md
@@ -59,11 +59,11 @@ Content-Type application/json
 
 {
    "id":8,
-   "new_request_notif":True,
-   "change_in_request_status_notif":True,
-   "request_approval_determined_notif":True,
-   "request_assigned_notif":True,
-   "reminder_notif":True,
+   "new_request_notif":true,
+   "change_in_request_status_notif":true,
+   "request_approval_determined_notif":true,
+   "request_assigned_notif":true,
+   "reminder_notif":true,
    "user":"UUID("   "8adbfcf0-7b4e-45b7-811a-f63a44d63c3d"   ")",
    "organization":3,
    "created_at":"2020-07-01T19:52:07+0000",

--- a/docs/api/user_settings.md
+++ b/docs/api/user_settings.md
@@ -35,7 +35,7 @@ Content-Type application/json
 }
 ```
 
-## Update an attachment
+## Update user settings
 
 **Request**:
 
@@ -70,7 +70,7 @@ Content-Type application/json
    "request_approval_determined_notif":true,
    "request_assigned_notif":true,
    "reminder_notif":true,
-   "user":"UUID("   "8adbfcf0-7b4e-45b7-811a-f63a44d63c3d"   ")",
+   "user":"8adbfcf0-7b4e-45b7-811a-f63a44d63c3d",
    "organization":3,
    "created_at":"2020-07-01T19:52:07+0000",
    "updated_at":"2020-07-01T19:52:07+0000"

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -1,6 +1,10 @@
 # Users
 Supports registering, viewing, and updating user accounts.
 
+## Description
+A user represents a single researcher or scientist on the site. A user is created using OAuth through ORCID, which allows each user to be associated with an ORCID.
+
+
 ## Register a new user account
 
 **Request**:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,3 +11,7 @@ nav:
   - API:
       - Authentication: 'api/authentication.md'
       - Users: 'api/users.md'
+      - Grants: 'api/grants.md'
+      - Materials: 'api/materials.md'
+      - Organizations: 'api/organizations.md'
+      - Search: 'api/search.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,3 +15,6 @@ nav:
       - Materials: 'api/materials.md'
       - Organizations: 'api/organizations.md'
       - Search: 'api/search.md'
+      - Attachments: 'api/attachments.md'
+      - Material Requests: 'api/material_requests.md'
+      - Notification Settings: 'api/user_settings.md'


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This PR adds API docs for the following endpoints: 
- Attachments
- Material Requests
- Organization User Settings

It also updates the nav menu to reflect all of these files.

Additional changes made just as I saw them:
- Made several more fields read-only on `material-request`.
- Automatically set the `requester` field on material-request to the user currently signed in.
- Fixed a typo or two.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New Feature

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules