### PR TITLE
Make trailing slashes in urls optional.

### DIFF
--- a/api/resources_portal/config/common.py
+++ b/api/resources_portal/config/common.py
@@ -69,7 +69,7 @@ class Common(Configuration):
     }
 
     # General
-    APPEND_SLASH = False
+    APPEND_SLASH = True
     TIME_ZONE = "UTC"
     LANGUAGE_CODE = "en-us"
     # If you set this to False, Django will make some optimizations so as not

--- a/api/resources_portal/urls.py
+++ b/api/resources_portal/urls.py
@@ -75,7 +75,7 @@ router.register(
 
 router.register(r"material-requests", MaterialRequestViewSet, basename="material-request")
 
-search_router = DefaultRouter(trailing_slash=False)
+search_router = DefaultRouter()
 search_router.register(r"materials", MaterialDocumentView, basename="search-materials")
 search_router.register(r"organizations", OrganizationDocumentView, basename="search-organizations")
 search_router.register(r"users", UserDocumentView, basename="search-users")

--- a/api/resources_portal/urls.py
+++ b/api/resources_portal/urls.py
@@ -29,7 +29,7 @@ from resources_portal.views import (
     local_file_view,
 )
 
-router = ExtendedSimpleRouter(trailing_slash=False)
+router = ExtendedSimpleRouter()
 router.register(r"users", UserViewSet, basename="user")
 router.register(r"users", UserViewSet, basename="user").register(
     r"organizations",


### PR DESCRIPTION
## Issue Number

N/A I noticed this and it's a pet peeve of mine.

## Purpose/Implementation Notes

Currently `/materials` works and `/materials/` doesn't. This makes them both work and all other routes too. It does so with redirects for SEO reasons. I prefer it when they both work when I'm using an API.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I tested `/materials` and `/materials`.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
