### PR TITLE
fix config path for client deploy

### DIFF
--- a/.github/workflows/deploy_client_prod.yml
+++ b/.github/workflows/deploy_client_prod.yml
@@ -18,4 +18,4 @@ jobs:
         run: yarn global add now
 
       - name: Deploy to Production
-        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.json --scope ccdl
+        run: cd client && $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.json --scope ccdl

--- a/.github/workflows/deploy_client_prod.yml
+++ b/.github/workflows/deploy_client_prod.yml
@@ -18,4 +18,4 @@ jobs:
         run: yarn global add now
 
       - name: Deploy to Production
-        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config now.json --scope ccdl
+        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.json --scope ccdl

--- a/.github/workflows/deploy_client_staging.yml
+++ b/.github/workflows/deploy_client_staging.yml
@@ -18,4 +18,4 @@ jobs:
         run: yarn global add now
 
       - name: Deploy to Staging
-        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.staging.json --scope ccdl
+        run: cd client && $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.staging.json --scope ccdl

--- a/.github/workflows/deploy_client_staging.yml
+++ b/.github/workflows/deploy_client_staging.yml
@@ -18,4 +18,4 @@ jobs:
         run: yarn global add now
 
       - name: Deploy to Staging
-        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config now.staging.json --scope ccdl
+        run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config ../now.staging.json --scope ccdl


### PR DESCRIPTION
## Issue Number

There was an issue with the github actions for client deploys where the config file was in the wrong directory. This is a test to see if we can reach up a dir, otherwise we will move the configs into the client folder