### PR TITLE
Filters list material request endpoint to only requests the user can view

### DIFF
--- a/api/resources_portal/test/views/test_material_request.py
+++ b/api/resources_portal/test/views/test_material_request.py
@@ -103,10 +103,21 @@ class TestMaterialRequestListTestCase(APITestCase):
         response = self.client.post(self.url, self.material_request_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_get_request_succeeds(self):
+    def test_get_request_from_sharer_succeeds(self):
         self.client.force_authenticate(user=self.sharer)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_request_from_requester_succeeds(self):
+        self.client.force_authenticate(user=self.request.requester)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_request_filters(self):
+        self.client.force_authenticate(user=self.user_without_perms)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 0)
 
     def test_get_request_from_unauthenticated_fails(self):
         self.client.force_authenticate(user=None)

--- a/api/resources_portal/test/views/test_material_request.py
+++ b/api/resources_portal/test/views/test_material_request.py
@@ -107,11 +107,13 @@ class TestMaterialRequestListTestCase(APITestCase):
         self.client.force_authenticate(user=self.sharer)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
 
     def test_get_request_from_requester_succeeds(self):
         self.client.force_authenticate(user=self.request.requester)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
 
     def test_get_request_filters(self):
         self.client.force_authenticate(user=self.user_without_perms)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/resources-portal/issues/283

## Purpose/Implementation Notes

Turns out https://www.django-rest-framework.org/api-guide/permissions/#limitations-of-object-level-permissions is a thing. Basically it doesn't work for list endpoints. I checked and this is actually the only place we were using it for lists.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit test I added was failing before I got this working.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
