### PR TITLE
Sync personal organizations' grants

### DIFF
--- a/api/resources_portal/models/associations/grant_organization_association.py
+++ b/api/resources_portal/models/associations/grant_organization_association.py
@@ -1,12 +1,11 @@
 from django.db import models
 
-from resources_portal.models.grant import Grant
 from resources_portal.models.organization import Organization
 
 
 class GrantOrganizationAssociation(models.Model):
 
-    grant = models.ForeignKey(Grant, blank=False, null=False, on_delete=models.CASCADE)
+    grant = models.ForeignKey("Grant", blank=False, null=False, on_delete=models.CASCADE)
     organization = models.ForeignKey(
         Organization, blank=False, null=False, on_delete=models.CASCADE
     )

--- a/api/resources_portal/models/grant.py
+++ b/api/resources_portal/models/grant.py
@@ -1,7 +1,13 @@
+from copy import copy
+
 from django.db import models
 
 from safedelete.managers import SafeDeleteDeletedManager, SafeDeleteManager
 from safedelete.models import SOFT_DELETE, SafeDeleteModel
+
+from resources_portal.models.associations.grant_organization_association import (
+    GrantOrganizationAssociation,
+)
 
 
 class Grant(SafeDeleteModel):
@@ -25,3 +31,44 @@ class Grant(SafeDeleteModel):
     )
     organizations = models.ManyToManyField("Organization", through="GrantOrganizationAssociation")
     materials = models.ManyToManyField("Material", through="GrantMaterialAssociation")
+
+    def set_on_personal_organiztion(self):
+        if self.user and self.user.personal_organization:
+            GrantOrganizationAssociation.get_or_create(
+                grant=self, organization=self.user.personal_organization
+            )
+
+    def save(self, *args, **kwargs):
+        """Keep the user's personal organization synced up.
+
+        Because we don't want the users to have to manage grant
+        relationships with their organizations, we want their personal
+        organization's grant list to stay in sync with their user's
+        grant list.
+        """
+        original = None
+        if self.id:
+            original = Grant.objects.get(pk=self.id)
+
+        super().save(*args, **kwargs)
+
+        if original:
+            if original.user != self.user:
+                # Grant user is changing, need to keep relationships
+                # with the personal organizations in sync.
+
+                # First remove the old association, if there was one.
+                if original.user and original.user.personal_organization:
+                    old_association = GrantOrganizationAssociation.objects.filter(
+                        grant=self, organization=original.user.personal_organization
+                    ).first()
+                    if old_association:
+                        old_association.delete()
+
+                # Then add the new association, if there's still an
+                # organization to add it to.
+                self.set_on_personal_organiztion()
+        else:
+            # This was just created, make sure the personal
+            # organization of user is linked if they both exist.
+            self.set_on_personal_organiztion()

--- a/api/resources_portal/models/grant.py
+++ b/api/resources_portal/models/grant.py
@@ -1,5 +1,3 @@
-from copy import copy
-
 from django.db import models
 
 from safedelete.managers import SafeDeleteDeletedManager, SafeDeleteManager

--- a/api/resources_portal/models/grant.py
+++ b/api/resources_portal/models/grant.py
@@ -34,7 +34,7 @@ class Grant(SafeDeleteModel):
 
     def set_on_personal_organiztion(self):
         if self.user and self.user.personal_organization:
-            GrantOrganizationAssociation.get_or_create(
+            GrantOrganizationAssociation.objects.get_or_create(
                 grant=self, organization=self.user.personal_organization
             )
 

--- a/api/resources_portal/test/views/test_grant.py
+++ b/api/resources_portal/test/views/test_grant.py
@@ -5,7 +5,7 @@ from rest_framework.test import APITestCase
 from faker import Faker
 
 from resources_portal.models import Grant, User
-from resources_portal.test.factories import GrantFactory, UserFactory
+from resources_portal.test.factories import GrantFactory, PersonalOrganizationFactory, UserFactory
 
 fake = Faker()
 
@@ -18,6 +18,9 @@ class TestGrantPostTestCase(APITestCase):
     def setUp(self):
         self.url = reverse("grant-list")
         self.grant = GrantFactory()
+        self.user = self.grant.user
+        self.user.personal_organization = PersonalOrganizationFactory(owner=self.user)
+        self.user.personal_organization.grants.set([self.grant])
 
     def test_post_request_with_no_data_fails(self):
         self.client.force_authenticate(user=self.grant.user)
@@ -25,7 +28,7 @@ class TestGrantPostTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_request_with_valid_data_succeeds(self):
-        self.client.force_authenticate(user=self.grant.user)
+        self.client.force_authenticate(user=self.user)
 
         get_url = reverse("grant-detail", args=[self.grant.id])
         grant_json = self.client.get(get_url).json()
@@ -33,6 +36,9 @@ class TestGrantPostTestCase(APITestCase):
 
         response = self.client.post(self.url, grant_json, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        grant = Grant.objects.get(id=response.json()["id"])
+        self.assertIn(grant, self.user.personal_organization.grants.all())
 
 
 class TestSingleGrantTestCase(APITestCase):
@@ -42,6 +48,9 @@ class TestSingleGrantTestCase(APITestCase):
 
     def setUp(self):
         self.grant = GrantFactory()
+        self.user = self.grant.user
+        self.user.personal_organization = PersonalOrganizationFactory(owner=self.user)
+        self.user.personal_organization.grants.set([self.grant])
         self.url = reverse("grant-detail", args=[self.grant.id])
 
     def test_get_request_returns_a_given_grant(self):
@@ -70,8 +79,8 @@ class TestSingleGrantTestCase(APITestCase):
         grant_json["title"] = new_title
         grant_json["funder_id"] = new_funder_id
 
-        # Test that users won't be updated.
         new_member = UserFactory()
+        new_member.personal_organization = PersonalOrganizationFactory(owner=new_member)
         grant_json["user"] = new_member.id
 
         response = self.client.put(self.url, grant_json)
@@ -81,9 +90,12 @@ class TestSingleGrantTestCase(APITestCase):
         self.assertEqual(new_title, self.grant.title)
         self.assertEqual(new_funder_id, self.grant.funder_id)
 
-        # This was ignored, requires using the relationship endpoiint.
         new_member = User.objects.get(id=new_member.id)
         self.assertEqual(new_member, self.grant.user)
+
+        # Make sure the grant got moved from the one personal organization to the other.
+        self.assertNotIn(self.grant, self.user.personal_organization.grants.all())
+        self.assertIn(self.grant, new_member.personal_organization.grants.all())
 
     def test_cannot_update_someone_elses_grant(self):
         user = UserFactory()
@@ -95,8 +107,10 @@ class TestSingleGrantTestCase(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_delete_only_soft_deletes_objects(self):
-        self.client.force_authenticate(user=self.grant.user)
+        self.client.force_authenticate(user=self.user)
         grant_id = self.grant.id
         response = self.client.delete(self.url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Grant.deleted_objects.filter(id=grant_id).count(), 1)
+
+        self.assertNotIn(self.grant, self.user.personal_organization.grants.all())


### PR DESCRIPTION
## Issue Number

#303 

## Purpose/Implementation Notes

#303 added the personal_organization, but the user won't have any way of managing its grants, so they just need to stay in sync with the user's grants.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests checkin it for me!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
