### PR TITLE
Fix deploy - set now-cli version

### DIFF
--- a/.github/workflows/deploy_client_staging.yml
+++ b/.github/workflows/deploy_client_staging.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install now
-        run: yarn global add now
+        run: yarn global add now@19.2.0
 
       - name: Deploy to Staging
         run: cd client && $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config now.staging.json --scope ccdl


### PR DESCRIPTION
## Issue Number

The deploys seem to have been broken since v20 so lets try rolling it back and then apply these changes to prod if that works