### PR TITLE
Add owned_public_organizations property.

### DIFF
--- a/api/resources_portal/models/material.py
+++ b/api/resources_portal/models/material.py
@@ -105,9 +105,7 @@ def fix_attachment_organizations(
         # Nothing to do during creation.
         return
 
-    attachments_needing_update = instance.sequence_maps.exclude(
-        owned_by_org=instance.organization
-    )
+    attachments_needing_update = instance.sequence_maps.exclude(owned_by_org=instance.organization)
     if attachments_needing_update.count() > 0:
         for attachment in attachments_needing_update.all():
             attachment.owned_by_org = instance.organization

--- a/api/resources_portal/models/user.py
+++ b/api/resources_portal/models/user.py
@@ -72,6 +72,10 @@ class User(AbstractUser, ComputedFieldsModel):
     def full_name(self):
         return f"{self.first_name} {self.last_name}"
 
+    @property
+    def owned_pulbic_organizations(self):
+        return self.owned_organizations.exclude(id=self.personal_organization.id)
+
     def save(self, *args, **kwargs):
         self.id = uuid.UUID(str(self.id))
         super(User, self).save(*args, **kwargs)

--- a/api/resources_portal/views/auth.py
+++ b/api/resources_portal/views/auth.py
@@ -98,7 +98,7 @@ class AuthViewSet(viewsets.ViewSet):
                 email=email,
             )
 
-            org = Organization.objects.create(owner=user)
+            org = Organization.objects.create(owner=user, title="Your Resources")
             user.personal_organization = org
 
             if "grant_info" in request.data:

--- a/api/resources_portal/views/auth.py
+++ b/api/resources_portal/views/auth.py
@@ -98,7 +98,7 @@ class AuthViewSet(viewsets.ViewSet):
                 email=email,
             )
 
-            org = Organization.objects.create(owner=user, title="Your Resources")
+            org = Organization.objects.create(owner=user, name="Your Resources")
             user.personal_organization = org
 
             if "grant_info" in request.data:

--- a/api/resources_portal/views/user.py
+++ b/api/resources_portal/views/user.py
@@ -29,6 +29,7 @@ class UserSerializer(serializers.ModelSerializer):
             "invitations",
             "organizations",
             "owned_organizations",
+            "owned_pulbic_organizations",
             "personal_organization",
             "assignments",
             "addresses",
@@ -47,6 +48,7 @@ class UserSerializer(serializers.ModelSerializer):
             "organizations",
             "addresses",
             "owned_organizations",
+            "owned_pulbic_organizations",
             "personal_organization",
         )
 
@@ -54,6 +56,7 @@ class UserSerializer(serializers.ModelSerializer):
     organizations = OrganizationRelationSerializer(many=True, read_only=True)
     personal_organization = OrganizationRelationSerializer(read_only=True)
     owned_organizations = OrganizationRelationSerializer(many=True, read_only=True)
+    owned_pulbic_organizations = OrganizationRelationSerializer(many=True, read_only=True)
     material_requests = MaterialRequestRelationSerializer(many=True, read_only=True)
     grants = GrantRelationSerializer(many=True, read_only=True)
     assignments = MaterialRequestRelationSerializer(many=True, read_only=True)


### PR DESCRIPTION
## Issue Number

N/A David just asked for these

## Purpose/Implementation Notes

Adds a owned_public_organizations property so the client doesn't always have to filter out the personal organization.

Also makes the personal org default to `Your Resources`

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None
