### PR TITLE
Add command to rportal to run black inside docker.

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -30,6 +30,7 @@ ipdb==0.12.3
 ipython==7.11.1
 mkdocs==1.0.4
 flake8==3.7.9
+black==19.10b0
 django-extensions==2.2.8
 
 # Testing

--- a/bin/rportal
+++ b/bin/rportal
@@ -37,7 +37,7 @@ commands = {
     "graph-models": run_api.format("./manage.py graph_models -a -g > model.dot"),
     "run-api": run_api,
     "manage-api": run_api.format("./manage.py {}"),
-    "run-black": "black --line-length=100 .",
+    "run-black": run_api.format("black --line-length=100 --exclude=volumes_postgres ."),
     "env": "cat ./docker-compose.env",
 }
 

--- a/bin/rportal
+++ b/bin/rportal
@@ -37,6 +37,7 @@ commands = {
     "graph-models": run_api.format("./manage.py graph_models -a -g > model.dot"),
     "run-api": run_api,
     "manage-api": run_api.format("./manage.py {}"),
+    "run-black": "black --line-length=100 .",
     "env": "cat ./docker-compose.env",
 }
 


### PR DESCRIPTION
## Issue Number

N/A 

## Purpose/Implementation Notes

Black sometimes uses the wrong version of python. This should make it easier to fix black for the project without everyone needing to configure their computer somehow.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran `rportal run-black` and it ran black.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
