### PR TITLE
Cleanup for create-account and redirect if there are no grants

### DIFF
--- a/client/src/components/CreateUser.js
+++ b/client/src/components/CreateUser.js
@@ -7,6 +7,7 @@ import {
 import { ProgressBar } from 'components/ProgressBar'
 import { Box, Heading } from 'grommet'
 import { useCreateUser } from 'hooks/useCreateUser'
+import { useRouter } from 'next/router'
 import React from 'react'
 
 export default ({ props }) => {
@@ -18,6 +19,11 @@ export default ({ props }) => {
     code,
     originUrl
   )
+  const router = useRouter()
+
+  if (!grants) {
+    router.replace('/')
+  }
 
   const [redirectAlreadyFired, setRedirectAlreadyFired] = React.useState(false)
 

--- a/client/src/components/CreateUser.js
+++ b/client/src/components/CreateUser.js
@@ -12,7 +12,7 @@ import React from 'react'
 
 export default ({ props }) => {
   const { ORCID, email, stepName, grants, code, originUrl } = props
-  const { steps, currentStep, setCurrentStep } = useCreateUser(
+  const { steps, currentStep, setCurrentStep, createUser } = useCreateUser(
     email,
     grants,
     ORCID,
@@ -21,7 +21,7 @@ export default ({ props }) => {
   )
   const router = useRouter()
 
-  if (!grants) {
+  if (!grants && !createUser.grants) {
     router.replace('/')
   }
 

--- a/client/src/contexts/CreateUserContext.js
+++ b/client/src/contexts/CreateUserContext.js
@@ -13,12 +13,14 @@ export const CreateUserContextProvider = ({ children }) => {
   const [error, setError] = React.useState('')
 
   // Cleanup localstorage without triggering events
-  const cleanup = () => {
-    window.localStorage.removeItem('createUser')
-    window.localStorage.removeItem('orcidInfo')
-    window.localStorage.removeItem('currentStep')
-    window.localStorage.removeItem('steps')
-    window.localStorage.removeItem('needsEmail')
+  const cleanup = (url) => {
+    if (!url.includes('orcid.org') && !url.includes('create-account')) {
+      window.localStorage.removeItem('createUser')
+      window.localStorage.removeItem('orcidInfo')
+      window.localStorage.removeItem('currentStep')
+      window.localStorage.removeItem('steps')
+      window.localStorage.removeItem('needsEmail')
+    }
   }
 
   return (

--- a/client/src/contexts/CreateUserContext.js
+++ b/client/src/contexts/CreateUserContext.js
@@ -13,14 +13,12 @@ export const CreateUserContextProvider = ({ children }) => {
   const [error, setError] = React.useState('')
 
   // Cleanup localstorage without triggering events
-  const cleanup = (url) => {
-    if (!url.includes('orcid.org') && !url.includes('create-account')) {
-      window.localStorage.removeItem('createUser')
-      window.localStorage.removeItem('orcidInfo')
-      window.localStorage.removeItem('currentStep')
-      window.localStorage.removeItem('steps')
-      window.localStorage.removeItem('needsEmail')
-    }
+  const cleanup = () => {
+    window.localStorage.removeItem('createUser')
+    window.localStorage.removeItem('orcidInfo')
+    window.localStorage.removeItem('currentStep')
+    window.localStorage.removeItem('steps')
+    window.localStorage.removeItem('needsEmail')
   }
 
   return (

--- a/client/src/contexts/CreateUserContext.js
+++ b/client/src/contexts/CreateUserContext.js
@@ -12,6 +12,15 @@ export const CreateUserContextProvider = ({ children }) => {
   const [authCodeUsed, setAuthCodeUsed] = React.useState(false)
   const [error, setError] = React.useState('')
 
+  // Cleanup localstorage without triggering events
+  const cleanup = () => {
+    window.localStorage.removeItem('createUser')
+    window.localStorage.removeItem('orcidInfo')
+    window.localStorage.removeItem('currentStep')
+    window.localStorage.removeItem('steps')
+    window.localStorage.removeItem('needsEmail')
+  }
+
   return (
     <CreateUserContext.Provider
       value={{
@@ -28,7 +37,8 @@ export const CreateUserContextProvider = ({ children }) => {
         authCodeUsed,
         setAuthCodeUsed,
         error,
-        setError
+        setError,
+        cleanup
       }}
     >
       {children}

--- a/client/src/hooks/useCreateUser.js
+++ b/client/src/hooks/useCreateUser.js
@@ -30,6 +30,12 @@ export const useCreateUser = (
   } = React.useContext(CreateUserContext)
   const router = useRouter()
 
+  const handleRouteChangeStart = (url) => {
+    if (!url.includes('orcid.org') && !url.includes('create-account')) {
+      cleanup()
+    }
+  }
+
   const save = () => {
     setCreateUser({ ...createUser })
   }
@@ -52,12 +58,12 @@ export const useCreateUser = (
   }
 
   React.useEffect(() => {
-    router.events.on('routeChangeStart', cleanup)
+    router.events.on('routeChangeStart', handleRouteChangeStart)
 
     // If the component is unmounted, unsubscribe
     // from the event with the `off` method:
     return () => {
-      router.events.off('routeChangeStart', cleanup)
+      router.events.off('routeChangeStart', handleRouteChangeStart)
     }
   })
 

--- a/client/src/hooks/useCreateUser.js
+++ b/client/src/hooks/useCreateUser.js
@@ -1,4 +1,5 @@
 import { CreateUserContext } from 'contexts/CreateUserContext'
+import { useRouter } from 'next/router'
 import React from 'react'
 import { string } from 'yup'
 import api from '../api'
@@ -24,8 +25,10 @@ export const useCreateUser = (
     needsEmail,
     setNeedsEmail,
     authCodeUsed,
-    setAuthCodeUsed
+    setAuthCodeUsed,
+    cleanup
   } = React.useContext(CreateUserContext)
+  const router = useRouter()
 
   const save = () => {
     setCreateUser({ ...createUser })
@@ -47,6 +50,16 @@ export const useCreateUser = (
     save()
     needsSave = false
   }
+
+  React.useEffect(() => {
+    router.events.on('routeChangeStart', cleanup)
+
+    // If the component is unmounted, unsubscribe
+    // from the event with the `off` method:
+    return () => {
+      router.events.off('routeChangeStart', cleanup)
+    }
+  })
 
   React.useEffect(() => {
     // If we have the auth code, get the ORCID info

--- a/client/src/pages/_app.js
+++ b/client/src/pages/_app.js
@@ -1,14 +1,14 @@
-import React from 'react'
 import { Grommet } from 'grommet'
 import Head from 'next/head'
-import theme from '../theme'
-import { Layout } from '../components/Layout'
+import React from 'react'
 import { AccountLayout } from '../components/AccountLayout'
 import { HomeLayout } from '../components/HomeLayout'
+import { Layout } from '../components/Layout'
 import { ResourcesPortalContextProvider } from '../ResourcesPortalContext'
-
 // global styles
 import '../styles/app.scss'
+import theme from '../theme'
+
 
 export default ({ Component, pageProps, router: { pathname } }) => {
   const isHome = pathname === '/'

--- a/client/src/pages/_app.js
+++ b/client/src/pages/_app.js
@@ -9,7 +9,6 @@ import { ResourcesPortalContextProvider } from '../ResourcesPortalContext'
 import '../styles/app.scss'
 import theme from '../theme'
 
-
 export default ({ Component, pageProps, router: { pathname } }) => {
   const isHome = pathname === '/'
   const isAccount = pathname.indexOf('/account') === 0


### PR DESCRIPTION
## Issue Number

N/a

## Purpose/Implementation Notes

This cleans up localstorage when you navigate to another page and redirects users hwo have no grants going to the /create-account page.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

