### PR TITLE
Import without create

### DIFF
--- a/api/resources_portal/__init__.py
+++ b/api/resources_portal/__init__.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+
+class ResourcesPortalConfig(AppConfig):
+    name = "resources_portal"
+
+    # This will be called multiple times
+    def ready(self):
+        import resources_portal.signals
+
+
+default_app_config = "resources_portal.ResourcesPortalConfig"

--- a/api/resources_portal/importers/geo.py
+++ b/api/resources_portal/importers/geo.py
@@ -17,8 +17,12 @@ def gather_all_metadata(experiment_accession_code):
         silent=True,
     )
 
+    # Sometimes title or pubmed_id is a list for some reason.
+    title = (
+        gse.metadata["title"][0] if type(gse.metadata["title"]) is list else gse.metadata["title"]
+    )
     metadata = {
-        "title": gse.metadata["title"],
+        "title": title,
         "description": "".join(gse.metadata["summary"]),
         "platform": gse.metadata["platform_id"],
         "technology": gse.metadata["type"],
@@ -26,7 +30,12 @@ def gather_all_metadata(experiment_accession_code):
     }
 
     if "pubmed_id" in gse.metadata:
-        metadata["pubmed_id"] = gse.metadata["pubmed_id"]
+        if type(gse.metadata["pubmed_id"]) is list:
+            pubmed_id = gse.metadata["pubmed_id"][0]
+        else:
+            pubmed_id = gse.metadata["pubmed_id"]
+
+        metadata["pubmed_id"] = pubmed_id
         metadata["publication_title"] = get_pubmed_publication_title(metadata["pubmed_id"])
 
     organisms = set()

--- a/api/resources_portal/importers/sra.py
+++ b/api/resources_portal/importers/sra.py
@@ -1,3 +1,4 @@
+import re
 import xml.etree.ElementTree as ET
 from typing import Dict
 
@@ -122,10 +123,12 @@ def _gather_study_metadata(study_accession: str) -> None:
 
 
 def _gather_experiment_metadata(metadata: Dict) -> None:
-    formatted_metadata_URL = ENA_METADATA_URL_TEMPLATE.format(metadata["experiment_accession"])
+    # We only need one accession.
+    first_accession = re.match(r"SRX\d+", metadata["experiment_accession"]).group()
+
+    formatted_metadata_URL = ENA_METADATA_URL_TEMPLATE.format(first_accession)
     response = requests_retry_session().get(formatted_metadata_URL)
     experiment_xml = ET.fromstring(response.text)
-
     experiment = experiment_xml[0]
     for child in experiment:
         if child.tag == "DESIGN":

--- a/api/resources_portal/importers/sra.py
+++ b/api/resources_portal/importers/sra.py
@@ -5,7 +5,7 @@ from resources_portal.importers.utils import get_pubmed_publication_title, reque
 
 ENA_URL_TEMPLATE = "https://www.ebi.ac.uk/ena/data/view/{}"
 
-ENA_METADATA_URL_TEMPLATE = "https://www.ebi.ac.uk/ena/data/view/{}&display=xml"
+ENA_METADATA_URL_TEMPLATE = "https://www.ebi.ac.uk/ena/data/view/{}?display=xml"
 
 
 class UnsupportedDataTypeError(Exception):

--- a/api/resources_portal/signals.py
+++ b/api/resources_portal/signals.py
@@ -56,7 +56,7 @@ def delete_document(sender, **kwargs):
 
 @receiver(m2m_changed, sender="resources_portal.OrganizationUserAssociation")
 def add_member_permissions(sender, instance, action, reverse, model, pk_set, **kwargs):
-    if action == "post_add":
+    if action == "post_add" and type(instance) is Organization:
         for member in instance.members.all():
             instance.assign_member_perms(member)
 

--- a/api/resources_portal/signals.py
+++ b/api/resources_portal/signals.py
@@ -1,7 +1,11 @@
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 
 from django_elasticsearch_dsl.registries import registry
+
+from resources_portal.models.material import Material
+from resources_portal.models.organization import Organization
+from resources_portal.models.user import User
 
 
 @receiver(post_save)
@@ -9,21 +13,20 @@ def update_document(sender, **kwargs):
     """Update document on added/changed records."""
     app_label = sender._meta.app_label
     model_name = sender._meta.model_name
-    instance = kwargs["instance"]
 
     if app_label == "resources_portal":
         if model_name == "resources_portal_user":
-            instances = instance.users.all()
+            instances = User.objects.all()
             for _instance in instances:
                 registry.update(_instance)
 
         if model_name == "organization":
-            instances = instance.organizations.all()
+            instances = Organization.objects.all()
             for _instance in instances:
                 registry.update(_instance)
 
         if model_name == "material":
-            instances = instance.materials.all()
+            instances = Material.objects.all()
             for _instance in instances:
                 registry.update(_instance)
 
@@ -33,20 +36,32 @@ def delete_document(sender, **kwargs):
     """Update document on deleted records."""
     app_label = sender._meta.app_label
     model_name = sender._meta.model_name
-    instance = kwargs["instance"]
 
     if app_label == "resources_portal":
         if model_name == "resources_portal_user":
-            instances = instance.users.all()
+            instances = User.objects.all()
             for _instance in instances:
                 registry.delete(_instance, raise_on_error=False)
 
     if model_name == "organization":
-        instances = instance.organizations.all()
+        instances = Organization.objects.all()
         for _instance in instances:
             registry.delete(_instance, raise_on_error=False)
 
     if model_name == "material":
-        instances = instance.materials.all()
+        instances = Material.objects.all()
         for _instance in instances:
             registry.delete(_instance, raise_on_error=False)
+
+
+@receiver(m2m_changed, sender="resources_portal.OrganizationUserAssociation")
+def add_member_permissions(sender, instance, action, reverse, model, pk_set, **kwargs):
+    if action == "post_add":
+        for member in instance.members.all():
+            instance.assign_member_perms(member)
+
+
+@receiver(post_save, sender="resources_portal.OrganizationUserAssociation")
+def add_member_permissions_2(sender, instance, **kwargs):
+    """Django doesn't appear to offer a way to manage this without handling all the signals."""
+    instance.organization.assign_member_perms(instance.user)

--- a/api/resources_portal/test/views/importers/test_geo.py
+++ b/api/resources_portal/test/views/importers/test_geo.py
@@ -18,11 +18,8 @@ class ImportGEOTestCase(APITestCase):
         self.test_accession_without_pubmed_id_num_samples = 3
 
         self.org = OrganizationFactory()
-        self.grant = GrantFactory()
         self.user = UserFactory()
-
-        self.user.grants.add(self.grant)
-        self.user.save()
+        self.grant = GrantFactory(user=self.user)
 
         self.org.members.add(self.user)
         self.org.save()
@@ -43,9 +40,6 @@ class ImportGEOTestCase(APITestCase):
         material_json["organization"] = self.org.id
 
         response = self.client.post(self.create_url, material_json)
-        import pdb
-
-        pdb.set_trace()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         material = Material.objects.get(pk=response.json()["id"])
@@ -55,7 +49,7 @@ class ImportGEOTestCase(APITestCase):
             material.additional_metadata["accession_code"], self.test_accession_with_pubmed_id
         )
         self.assertEqual(
-            material.additional_metadata["num_samples"],
+            material.additional_metadata["number_samples"],
             self.test_accession_with_pubmed_id_num_samples,
         )
 
@@ -79,12 +73,11 @@ class ImportGEOTestCase(APITestCase):
         material = Material.objects.get(pk=response.json()["id"])
 
         self.assertEqual(material.organization, self.org)
-        self.assertEqual(material.grants.first(), self.grant)
         self.assertEqual(
             material.additional_metadata["accession_code"], self.test_accession_without_pubmed_id
         )
         self.assertEqual(
-            material.additional_metadata["num_samples"],
+            material.additional_metadata["number_samples"],
             self.test_accession_without_pubmed_id_num_samples,
         )
 

--- a/api/resources_portal/test/views/importers/test_geo.py
+++ b/api/resources_portal/test/views/importers/test_geo.py
@@ -26,27 +26,31 @@ class ImportGEOTestCase(APITestCase):
 
         self.org.members.add(self.user)
         self.org.save()
+        self.url = reverse("materials-import")
+        self.create_url = reverse("material-list")
 
     def test_import_succeeds_for_study_with_pubmed_id(self):
         self.client.force_authenticate(user=self.user)
 
-        url = reverse("materials-import")
         response = self.client.post(
-            url,
-            {
-                "import_type": "GEO",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
+            self.url,
+            {"import_source": "GEO", "study_accession": self.test_accession_with_pubmed_id,},
         )
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        material_json = response.json()
+        material_json["organization"] = self.org.id
+
+        response = self.client.post(self.create_url, material_json)
+        import pdb
+
+        pdb.set_trace()
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         material = Material.objects.get(pk=response.json()["id"])
 
         self.assertEqual(material.organization, self.org)
-        self.assertEqual(material.grants.first(), self.grant)
         self.assertEqual(
             material.additional_metadata["accession_code"], self.test_accession_with_pubmed_id
         )
@@ -61,14 +65,15 @@ class ImportGEOTestCase(APITestCase):
         url = reverse("materials-import")
         response = self.client.post(
             url,
-            {
-                "import_type": "GEO",
-                "study_accession": self.test_accession_without_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
+            {"import_source": "GEO", "study_accession": self.test_accession_without_pubmed_id,},
         )
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        material_json = response.json()
+        material_json["organization"] = self.org.id
+
+        response = self.client.post(self.create_url, material_json)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         material = Material.objects.get(pk=response.json()["id"])
@@ -88,49 +93,11 @@ class ImportGEOTestCase(APITestCase):
         response = self.client.post(
             url,
             {
-                "import_type": "GEO",
+                "import_source": "GEO",
                 "study_accession": self.test_accession_with_pubmed_id,
                 "organization_id": self.org.id,
                 "grant_id": self.grant.id,
             },
         )
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_import_from_user_who_does_not_own_grant_fails(self):
-        self.client.force_authenticate(user=self.user)
-
-        self.org.members.remove(self.user)
-        self.org.save()
-
-        url = reverse("materials-import")
-        response = self.client.post(
-            url,
-            {
-                "import_type": "GEO",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_import_from_user_not_in_organization_fails(self):
-        self.client.force_authenticate(user=self.user)
-
-        self.user.grants.remove(self.grant)
-        self.user.save()
-
-        url = reverse("materials-import")
-        response = self.client.post(
-            url,
-            {
-                "import_type": "GEO",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/api/resources_portal/test/views/importers/test_sra.py
+++ b/api/resources_portal/test/views/importers/test_sra.py
@@ -26,21 +26,23 @@ class ImportSRATestCase(APITestCase):
 
         self.org.members.add(self.user)
         self.org.save()
+        self.url = reverse("materials-import")
+        self.create_url = reverse("material-list")
 
     def test_import_succeeds_for_study_with_pubmed_id(self):
         self.client.force_authenticate(user=self.user)
 
-        url = reverse("materials-import")
         response = self.client.post(
-            url,
-            {
-                "import_type": "SRA",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
+            self.url,
+            {"import_source": "SRA", "study_accession": self.test_accession_with_pubmed_id,},
         )
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        material_json = response.json()
+        material_json["organization"] = self.org.id
+
+        response = self.client.post(self.create_url, material_json)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         material = Material.objects.get(pk=response.json()["id"])
@@ -58,16 +60,17 @@ class ImportSRATestCase(APITestCase):
     def test_import_succeeds_for_study_without_pubmed_id(self):
         self.client.force_authenticate(user=self.user)
 
-        url = reverse("materials-import")
         response = self.client.post(
-            url,
-            {
-                "import_type": "SRA",
-                "study_accession": self.test_accession_without_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
+            self.url,
+            {"import_source": "SRA", "study_accession": self.test_accession_without_pubmed_id,},
         )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        material_json = response.json()
+        material_json["organization"] = self.org.id
+
+        response = self.client.post(self.create_url, material_json)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -84,53 +87,9 @@ class ImportSRATestCase(APITestCase):
         )
 
     def test_import_from_unauthenticated_fails(self):
-        url = reverse("materials-import")
         response = self.client.post(
-            url,
-            {
-                "import_type": "SRA",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
+            self.url,
+            {"import_source": "SRA", "study_accession": self.test_accession_with_pubmed_id,},
         )
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_import_from_user_who_does_not_own_grant_fails(self):
-        self.client.force_authenticate(user=self.user)
-
-        self.org.members.remove(self.user)
-        self.org.save()
-
-        url = reverse("materials-import")
-        response = self.client.post(
-            url,
-            {
-                "import_type": "SRA",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_import_from_user_not_in_organization_fails(self):
-        self.client.force_authenticate(user=self.user)
-
-        self.user.grants.remove(self.grant)
-        self.user.save()
-
-        url = reverse("materials-import")
-        response = self.client.post(
-            url,
-            {
-                "import_type": "SRA",
-                "study_accession": self.test_accession_with_pubmed_id,
-                "organization_id": self.org.id,
-                "grant_id": self.grant.id,
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/api/resources_portal/test/views/importers/test_sra.py
+++ b/api/resources_portal/test/views/importers/test_sra.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from resources_portal.models import Material
-from resources_portal.test.factories import GrantFactory, OrganizationFactory, UserFactory
+from resources_portal.test.factories import OrganizationFactory, UserFactory
 
 
 class ImportSRATestCase(APITestCase):
@@ -18,11 +18,7 @@ class ImportSRATestCase(APITestCase):
         self.test_accession_without_pubmed_id_num_samples = 6
 
         self.org = OrganizationFactory()
-        self.grant = GrantFactory()
         self.user = UserFactory()
-
-        self.user.grants.add(self.grant)
-        self.user.save()
 
         self.org.members.add(self.user)
         self.org.save()
@@ -48,12 +44,11 @@ class ImportSRATestCase(APITestCase):
         material = Material.objects.get(pk=response.json()["id"])
 
         self.assertEqual(material.organization, self.org)
-        self.assertEqual(material.grants.first(), self.grant)
         self.assertEqual(
             material.additional_metadata["accession_code"], self.test_accession_with_pubmed_id
         )
         self.assertEqual(
-            material.additional_metadata["num_samples"],
+            material.additional_metadata["number_samples"],
             self.test_accession_with_pubmed_id_num_samples,
         )
 
@@ -77,12 +72,11 @@ class ImportSRATestCase(APITestCase):
         material = Material.objects.get(pk=response.json()["id"])
 
         self.assertEqual(material.organization, self.org)
-        self.assertEqual(material.grants.first(), self.grant)
         self.assertEqual(
             material.additional_metadata["accession_code"], self.test_accession_without_pubmed_id
         )
         self.assertEqual(
-            material.additional_metadata["num_samples"],
+            material.additional_metadata["number_samples"],
             self.test_accession_without_pubmed_id_num_samples,
         )
 

--- a/api/resources_portal/test/views/test_material.py
+++ b/api/resources_portal/test/views/test_material.py
@@ -33,7 +33,7 @@ class TestMaterialListTestCase(APITestCase):
     def test_post_request_with_no_data_fails(self):
         self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, {})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_post_request_with_valid_data_succeeds(self):
         self.client.force_authenticate(user=self.user)

--- a/api/resources_portal/test/views/test_organization.py
+++ b/api/resources_portal/test/views/test_organization.py
@@ -23,6 +23,12 @@ class TestOrganizationPostTestCase(APITestCase):
         self.url = reverse("organization-list")
         self.organization = PersonalOrganizationFactory()
 
+    def test_list_succeeds(self):
+        self.client.force_authenticate(user=self.organization.owner)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+
     def test_post_request_with_no_data_fails(self):
         self.client.force_authenticate(user=self.organization.owner)
         response = self.client.post(self.url, {})

--- a/api/resources_portal/views/grant_material.py
+++ b/api/resources_portal/views/grant_material.py
@@ -27,7 +27,7 @@ class OwnsGrantAndMaterial(BasePermission):
         # OwnsGrant.
         return (
             request.user == grant.user
-            and request.user == material.organization.owner
+            and request.user in material.organization.members.all()
             and grant in material.organization.grants.all()
         )
 

--- a/api/resources_portal/views/import_materials.py
+++ b/api/resources_portal/views/import_materials.py
@@ -1,14 +1,12 @@
-from django.forms.models import model_to_dict
 from django.http import JsonResponse
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from resources_portal.importers import geo, protocols_io, sra
 from resources_portal.importers.protocols_io import ProtocolNotFoundError
-from resources_portal.models import Grant, Material, Organization
 
 
-def import_dataset(import_source, accession_code, organization, grant, user):
+def import_dataset(import_source, accession_code, user):
     """This function returns a Response object containing the json
     representation of the newly-created material object made using
     metadata from the import_source's API.
@@ -33,14 +31,13 @@ def import_dataset(import_source, accession_code, organization, grant, user):
         }
 
         material_json = {
-            "organization": organization,
             "category": "DATASET",
             "imported": True,
             "import_source": import_source,
             "title": metadata["title"],
             "organisms": metadata["organism_names"],
             "url": metadata["url"],
-            "contact_user": user,
+            "contact_user": str(user.id),
             "additional_metadata": additional_metadata,
         }
 
@@ -49,26 +46,15 @@ def import_dataset(import_source, accession_code, organization, grant, user):
             material_json["pubmed_id"] = metadata["pubmed_id"]
             material_json["publication_title"] = metadata["publication_title"]
 
-        material = Material(**material_json)
-        material.save()
-
-        material.grants.set([grant])
+        return material_json
 
     except KeyError as error:
-        return JsonResponse(
-            {
-                "error": f"Unable to import SRA. The following attribute was not found: {str(error)}."
-            },
-            status=400,
-        )
-
-    material_json = model_to_dict(material)
-    material_json["grants"] = [material_json["grants"][0].id]
-
-    return JsonResponse(material_json, status=201)
+        return {
+            "error": f"Unable to import SRA. The following attribute was not found: {str(error)}."
+        }
 
 
-def import_protocol(protocol_doi, organization, grant, user):
+def import_protocol(protocol_doi, user):
     """
     This function returns a Response object containing
     the json representation of the newly-created material object
@@ -90,24 +76,16 @@ def import_protocol(protocol_doi, organization, grant, user):
     }
 
     material_json = {
-        "organization": organization,
         "category": "PROTOCOL",
         "imported": True,
         "import_source": "PROTOCOLS_IO",
         "title": metadata["protocol_name"],
         "url": metadata["url"],
-        "contact_user": user,
+        "contact_user": str(user.id),
         "additional_metadata": additional_metadata,
     }
 
-    material = Material(**material_json)
-    material.save()
-    material.grants.set([grant])
-
-    material_json = model_to_dict(material)
-    material_json["grants"] = [material_json["grants"][0].id]
-
-    return JsonResponse(material_json, status=201)
+    return material_json
 
 
 class ImportViewSet(viewsets.ViewSet):
@@ -118,27 +96,24 @@ class ImportViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]
 
     def create(self, request, *args, **kwargs):
-        organization = Organization.objects.get(pk=request.data["organization_id"])
-        grant = Grant.objects.get(pk=request.data["grant_id"])
+        import_source = request.data["import_source"]
 
-        if grant not in request.user.grants.all():
-            return JsonResponse({"error": f"The user does not own grant id {grant.id}"}, status=403)
-
-        if request.user not in organization.members.all():
-            return JsonResponse(
-                {"error": f"The user is not a member of organization id {organization.id}"},
-                status=403,
+        if import_source == "SRA" or import_source == "GEO":
+            material_json = import_dataset(
+                import_source, request.data["study_accession"], request.user
             )
-
-        import_type = request.data["import_type"]
-
-        if import_type == "SRA" or import_type == "GEO":
-            return import_dataset(
-                import_type, request.data["study_accession"], organization, grant, request.user
-            )
-        elif import_type == "PROTOCOLS_IO":
-            return import_protocol(request.data["protocol_doi"], organization, grant, request.user)
+        elif import_source == "PROTOCOLS_IO":
+            material_json = import_protocol(request.data["protocol_doi"], request.user)
         else:
             return JsonResponse(
-                {"error": f'Invalid value for parameter "import_type": {import_type}.'}, status=400
+                {"error": f'Invalid value for parameter "import_source": {import_source}.'},
+                status=400,
             )
+
+        if "error" in material_json:
+            return JsonResponse(
+                {"error": f'Invalid value for parameter "import_source": {import_source}.'},
+                status=400,
+            )
+        else:
+            return JsonResponse(material_json, status=200)

--- a/api/resources_portal/views/import_materials.py
+++ b/api/resources_portal/views/import_materials.py
@@ -64,9 +64,7 @@ def import_protocol(protocol_doi, user):
     try:
         metadata = protocols_io.gather_all_metadata(protocol_doi)
     except ProtocolNotFoundError:
-        return JsonResponse(
-            {"error": f"The protocol matching DOI {protocol_doi} could not be found"}, status=400,
-        )
+        return {"error": f"The protocol matching DOI {protocol_doi} could not be found"}
 
     additional_metadata = {
         "protocol_name": metadata["protocol_name"],

--- a/api/resources_portal/views/material.py
+++ b/api/resources_portal/views/material.py
@@ -77,6 +77,9 @@ class MaterialDetailSerializer(MaterialSerializer):
 
 class HasAddResources(BasePermission):
     def has_permission(self, request, view):
+        if "organization" not in request.data:
+            return False
+
         organization = Organization.objects.get(id=request.data["organization"])
         return request.user.has_perm("add_resources", organization)
 
@@ -102,11 +105,11 @@ class MaterialViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 
     def get_permissions(self):
         if self.action == "create":
-            permission_classes = [HasAddResources, IsAuthenticated]
+            permission_classes = [IsAuthenticated, HasAddResources]
         elif self.action == "destroy":
-            permission_classes = [HasDeleteResources, IsAuthenticated]
+            permission_classes = [IsAuthenticated, HasDeleteResources]
         elif self.action == "update" or self.action == "partial_update":
-            permission_classes = [HasEditResources, IsAuthenticated]
+            permission_classes = [IsAuthenticated, HasEditResources]
         else:
             permission_classes = []
 

--- a/api/resources_portal/views/material.py
+++ b/api/resources_portal/views/material.py
@@ -76,8 +76,9 @@ class MaterialDetailSerializer(MaterialSerializer):
 
 
 class HasAddResources(BasePermission):
-    def has_object_permission(self, request, view, obj):
-        return request.user.has_perm("add_resources", obj.organization)
+    def has_permission(self, request, view):
+        organization = Organization.objects.get(id=request.data["organization"])
+        return request.user.has_perm("add_resources", organization)
 
 
 class HasDeleteResources(BasePermission):

--- a/docs/api/import_materials.md
+++ b/docs/api/import_materials.md
@@ -11,14 +11,14 @@ Parameters:
 
 Name                           | Type   | Description
 -------------------------------|--------|---
-import_type                    | string | The type of resource being imported. Options include: ["SRA", "GEO", "PROTOCOLS_IO"].
+import_source                    | string | The source of resource being imported. Options include: ["SRA", "GEO", "PROTOCOLS_IO"].
 accession                      | int    | The accession code for the study representing the material, in the form "SRP123456" for SRA or "GSE123456" for GEO.
 organization_id                | int    | The ID of the organization that this material will be owned by.
 grant_id                       | int    | The ID of the grant that this material will be associated with.
 
 *Note:*
 
-- To import a material from SRA or GEO, set "import_type" to the corresponding value.
+- To import a material from SRA or GEO, set "import_source" to the corresponding value.
 - All parameters are required.
 - **[Authorization Protected](authentication.md)**
 - The user making the request must own the given grant and be a part of the given organization.
@@ -75,14 +75,14 @@ Parameters:
 
 Name                           | Type   | Description
 -------------------------------|--------|---
-import_type                    | string | The type of resource being imported. Options include: ["SRA", "GEO", "PROTOCOLS_IO"].
+import_source                    | string | The source of resource being imported. Options include: ["SRA", "GEO", "PROTOCOLS_IO"].
 protocol_doi                   | int    | The DOI of the protocol in question. This can be taken from a protocol's page on protocols.io, and is in the form "dx.doi.org/10.17504/protocols.io.c4gytv"
 organization_id                | int    | The ID of the organization that this material will be owned by.
 grant_id                       | int    | The ID of the grant that this material will be associated with.
 
 *Note:*
 
-- To import a protocols.io material, ```import_type``` must be set to "PROTOCOLS_IO".
+- To import a protocols.io material, ```import_source``` must be set to "PROTOCOLS_IO".
 - All parameters are required.
 - **[Authorization Protected](authentication.md)**
 - The user making the request must own the given grant and be a part of the given organization.


### PR DESCRIPTION
## Issue Number

N/A, David needs it

## Purpose/Implementation Notes

The goal is to just return the material JSON after importing, rather than actually saving it. This does that, along with fixing some bugs I found along the way.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Unit tests! They test the flow for importing materials including POSTing the material and then setting the grant.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
