### PR TITLE
Remove temporary code to reset staging database.

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -151,18 +151,6 @@ def run_terraform(args):
 
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
-        # Temporary to reset database!
-        terraform_process = subprocess.Popen(
-            ["terraform", "taint", "aws_db_instance.postgres_db"], stdout=subprocess.PIPE
-        )
-        output = ""
-        for line in iter(terraform_process.stdout.readline, b""):
-            decoded_line = line.decode("utf-8")
-            print(decoded_line, end="")
-            output += decoded_line
-
-        terraform_process.wait()
-
         terraform_process = subprocess.Popen(
             ["terraform", "apply", var_file_arg, "-auto-approve"], stdout=subprocess.PIPE
         )


### PR DESCRIPTION
## Issue Number

#424 

## Purpose/Implementation Notes

#424 added a change to taint the database to reset migrations. This undoes that so we don't lose our database every deploy.
