### PR TITLE
deploy to stage after previews are done

### DIFF
--- a/.github/workflows/deploy_client_staging.yml
+++ b/.github/workflows/deploy_client_staging.yml
@@ -1,9 +1,6 @@
 name: deploy-client-staging
 
-on:
-  push:
-    branches:
-      - dev
+on: push
 
 jobs:
   deploy-client-staging:


### PR DESCRIPTION
## Issue Number
N/A 

The staging server needs to be redeployed after previews are created otherwise it gets overridden with prod config.