### PR TITLE
remove bar from more options

### DIFF
--- a/client/src/components/resources/ManageResourceCard.js
+++ b/client/src/components/resources/ManageResourceCard.js
@@ -55,11 +55,6 @@ export const ManageOptions = ({
       )}
       {options.includes('archive') && (
         <>
-          <Box
-            border={{ side: 'bottom', color: 'border-black', size: 'small' }}
-          >
-            <Text>Archive Resource</Text>
-          </Box>
           <Anchor
             icon={<Icon name="Archive" size="small" />}
             label="Archive"


### PR DESCRIPTION
## Issue Number

N/A there was some artifact in the `More Options` dropdown - there was extra text that was supposed to have been removed.
This removes it

![Screen Shot 2020-09-29 at 12 38 40 PM](https://user-images.githubusercontent.com/1075609/94587535-bc9d5980-0250-11eb-8148-8ce56c286a59.png)
