### PR TITLE
teams invites / add members to existing team

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -235,6 +235,12 @@ export default {
         method: 'POST',
         body: JSON.stringify(organization)
       }),
+    update: (organizationId, organization, authorization) =>
+      request(getAPIURL(`organizations/${organizationId}/`), {
+        authorization,
+        method: 'PATCH',
+        body: JSON.stringify(organization)
+      }),
     grants: {
       get: (organizationId, authorization) =>
         request(getAPIURL(`organizations/${organizationId}/grants/`), {

--- a/client/src/components/TeamAddMembers.js
+++ b/client/src/components/TeamAddMembers.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Box, Button, FormField, TextInput, Text } from 'grommet'
+import TeamMembersTable from 'components/TeamMembersTable'
+import useTeamForm from 'hooks/useTeamForm'
+
+export default ({ showActions = true }) => {
+  const {
+    team,
+    removeMember,
+    getAttribute,
+    memberSuggestions,
+    updateMemberSuggestions,
+    addMemberOrInvite,
+    memberEmail,
+    setMemberEmail,
+    invites,
+    removeInvite
+  } = useTeamForm()
+  const members = getAttribute('members')
+
+  return (
+    <>
+      <FormField label="Email">
+        <TextInput
+          value={memberEmail}
+          onChange={({ target: { value } }) => {
+            updateMemberSuggestions(value)
+            setMemberEmail(value)
+          }}
+          onSelect={({ suggestion: { value } }) => {
+            setMemberEmail(value.email)
+          }}
+          suggestions={memberSuggestions[memberEmail] || []}
+        />
+      </FormField>
+      <Box pad={{ vertical: 'medium' }} align="start">
+        <Button
+          primary
+          label="Add Member"
+          onClick={addMemberOrInvite}
+          disabled={memberEmail === ''}
+        />
+      </Box>
+      <Box>
+        {members.length > 0 && (
+          <Box margin={{ bottom: 'medium' }}>
+            <Text weight="bold">Added Memebers</Text>
+            <TeamMembersTable team={team} onDelete={removeMember} />
+          </Box>
+        )}
+
+        {invites.length > 0 && (
+          <Box margin={{ bottom: 'medium' }}>
+            <Text weight="bold">Invited Members</Text>
+            <TeamMembersTable
+              team={{ ...team, members: invites }}
+              onDelete={removeInvite}
+            />
+          </Box>
+        )}
+      </Box>
+    </>
+  )
+}

--- a/client/src/components/TeamAddMembers.js
+++ b/client/src/components/TeamAddMembers.js
@@ -3,7 +3,7 @@ import { Box, Button, FormField, TextInput, Text } from 'grommet'
 import TeamMembersTable from 'components/TeamMembersTable'
 import useTeamForm from 'hooks/useTeamForm'
 
-export default ({ showActions = true }) => {
+export default () => {
   const {
     team,
     removeMember,

--- a/client/src/components/TeamForm.js
+++ b/client/src/components/TeamForm.js
@@ -10,28 +10,12 @@ import {
 } from 'grommet'
 import Link from 'next/link'
 import { HeaderRow } from 'components/HeaderRow'
-import TeamMembersTable from 'components/TeamMembersTable'
+import TeamAddMembers from 'components/TeamAddMembers'
 import useTeamForm from 'hooks/useTeamForm'
 import { useRouter } from 'next/router'
 
 export default ({ teamId }) => {
-  const {
-    user,
-    team,
-    setAttribute,
-    getAttribute,
-    fetchTeam,
-    memberSuggestions,
-    updateMemberSuggestions,
-    save,
-    addMemberOrInvite,
-    removeMember,
-    memberEmail,
-    setMemberEmail,
-    invites,
-    removeInvite
-  } = useTeamForm()
-  const members = getAttribute('members')
+  const { user, setAttribute, getAttribute, fetchTeam, save } = useTeamForm()
   const router = useRouter()
   React.useEffect(() => {
     if (teamId) fetchTeam(teamId)
@@ -62,46 +46,8 @@ export default ({ teamId }) => {
           request requirements. Only the owner (you) can add new members and
           remove resources.
         </Text>
-        <FormField label="Email">
-          <TextInput
-            value={memberEmail}
-            onChange={({ target: { value } }) => {
-              updateMemberSuggestions(value)
-              setMemberEmail(value)
-            }}
-            onSelect={({ suggestion: { value } }) => {
-              setMemberEmail(value.email)
-            }}
-            suggestions={memberSuggestions[memberEmail] || []}
-          />
-        </FormField>
-        <Box pad={{ vertical: 'medium' }} align="start">
-          <Button
-            primary
-            label="Add Member"
-            onClick={addMemberOrInvite}
-            disabled={memberEmail === ''}
-          />
-        </Box>
       </Box>
-      <Box>
-        {members.length > 0 && (
-          <Box margin={{ bottom: 'medium' }}>
-            <Text weight="bold">Added Memebers</Text>
-            <TeamMembersTable team={team} onDelete={removeMember} />
-          </Box>
-        )}
-
-        {invites.length > 0 && (
-          <Box margin={{ bottom: 'medium' }}>
-            <Text weight="bold">Invited Members</Text>
-            <TeamMembersTable
-              team={{ ...team, members: invites }}
-              onDelete={removeInvite}
-            />
-          </Box>
-        )}
-      </Box>
+      <TeamAddMembers />
       <Box>
         {user.grants.length === 0 && (
           <Text color="black-tint-60" italic>

--- a/client/src/components/TeamGrants.js
+++ b/client/src/components/TeamGrants.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import { Box, Button, CheckBox, Paragraph, Text } from 'grommet'
+import { Modal } from 'components/Modal'
+import { HeaderRow } from 'components/HeaderRow'
+import Icon from 'components/Icon'
+import useTeamForm from 'hooks/useTeamForm'
+
+export default () => {
+  const {
+    user,
+    fetchTeam,
+    addGrant,
+    removeGrant,
+    team: { grants, id: teamId }
+  } = useTeamForm()
+  const [showGrantsModal, setShowGrantsModal] = React.useState(false)
+  return (
+    <Box pad={{ vertical: 'medium' }}>
+      {grants.length === 0 && (
+        <Text italic color="black-tint-60">
+          You have no linked grants.
+        </Text>
+      )}
+      <Button
+        alignSelf="end"
+        primary
+        label="Link Grants"
+        onClick={() => setShowGrantsModal(true)}
+      />
+      <Modal showing={showGrantsModal} setShowing={setShowGrantsModal}>
+        <Box width="large">
+          <Box border={{ side: 'bottom' }} margin={{ bottom: 'medium' }}>
+            <Text serif size="xlarge">
+              Link Grants
+            </Text>
+          </Box>
+          <Text>
+            Members of your team may only add resources and manage requests
+            linked with a particular grant. Select the grant(s) below to
+            associate with this team.
+          </Text>
+          <Text weight="bold" margin={{ vertical: 'medium' }}>
+            Grants awarded to you (choose as many as appropriate)
+          </Text>
+          {user.grants.length === 0 && (
+            <Paragraph>You have no grants.</Paragraph>
+          )}
+          {user.grants.map((grant) => (
+            <CheckBox
+              key={grant.id}
+              label={grant.title}
+              checked={grants.map((g) => g.id).includes(grant.id)}
+              onChange={async ({ target: { checked } }) => {
+                if (checked) await addGrant(teamId, grant.id)
+                if (!checked) await removeGrant(teamId, grant.id)
+                fetchTeam(teamId)
+              }}
+            />
+          ))}
+          <Button
+            primary
+            alignSelf="end"
+            margin={{ vertical: 'medium' }}
+            label="Done"
+            onClick={() => {
+              setShowGrantsModal(false)
+            }}
+          />
+        </Box>
+      </Modal>
+      {grants.length > 0 && (
+        <>
+          <HeaderRow label={`Grants (${grants.length})`} />
+          {grants.map(({ title, funder_id: funderId, id }) => (
+            <Box key={funderId} direction="row" justify="between">
+              <Box direction="row" align="center">
+                <Icon color="plain" name="Grant" />
+                <Box pad={{ left: 'small' }}>
+                  <Paragraph margin="none">{title}</Paragraph>
+                  <Paragraph size="small">Grant ID:{funderId}</Paragraph>
+                </Box>
+              </Box>
+              <Button
+                plain
+                size="small"
+                color="error"
+                icon={<Icon name="Trashcan" color="error" size="small" />}
+                label="Remove"
+                onClick={async () => {
+                  await removeGrant(teamId, id)
+                  fetchTeam(teamId)
+                }}
+              />
+            </Box>
+          ))}
+        </>
+      )}
+    </Box>
+  )
+}

--- a/client/src/components/TeamMembers.js
+++ b/client/src/components/TeamMembers.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Box, Button, Text } from 'grommet'
+import { HeaderRow } from 'components/HeaderRow'
+import TeamMembersTable from 'components/TeamMembersTable'
+import useTeamForm from 'hooks/useTeamForm'
+import { Modal } from 'components/Modal'
+import TeamAddMembers from 'components/TeamAddMembers'
+import { useAlertsQueue } from 'hooks/useAlertsQueue'
+
+export default () => {
+  const { addAlert } = useAlertsQueue()
+  const { team, removeMember, invites, save } = useTeamForm()
+  const [showTeamModal, setShowTeamModal] = React.useState(false)
+  const saveChanges = async (message) => {
+    if (await save()) {
+      addAlert(message, 'success')
+    } else {
+      addAlert('An error occurred while saving. Please refresh.', 'error')
+    }
+  }
+  return (
+    <Box pad={{ vertical: 'medium' }}>
+      {team.members.length === 0 && (
+        <Text italic color="black-tint-60">
+          You have no members.
+        </Text>
+      )}
+      <Box direction="row" justify="end">
+        <Button label="Add Members" onClick={() => setShowTeamModal(true)} />
+        <Modal
+          showing={showTeamModal}
+          setShowing={setShowTeamModal}
+          title="Add Members"
+        >
+          <Box width="large">
+            <TeamAddMembers showActions={false} />
+            <Box direction="row" justify="end">
+              <Button
+                label="Done"
+                onClick={async () => {
+                  if (invites.length) {
+                    await saveChanges('Invites Sent')
+                  }
+                  setShowTeamModal(false)
+                }}
+              />
+            </Box>
+          </Box>
+        </Modal>
+      </Box>
+      <HeaderRow label={`Members (${team.members.length})`} />
+      <TeamMembersTable
+        team={team}
+        onDelete={(member) => {
+          removeMember(member)
+          saveChanges('Member Removed')
+        }}
+      />
+    </Box>
+  )
+}

--- a/client/src/components/TeamResources.js
+++ b/client/src/components/TeamResources.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Box, Text } from 'grommet'
+import { HeaderRow } from 'components/HeaderRow'
+import { ManageResourceCard } from 'components/resources/ManageResourceCard'
+import useTeamForm from 'hooks/useTeamForm'
+
+export default () => {
+  const {
+    team: { materials: resources }
+  } = useTeamForm()
+  return (
+    <Box pad={{ vertical: 'medium' }}>
+      {resources.length === 0 && (
+        <Text italic color="black-tint-60">
+          You have no resources.
+        </Text>
+      )}
+      {resources.length > 0 && (
+        <>
+          <HeaderRow label={`Resources (${resources.length})`} />
+          <Box margin={{ top: 'medium' }}>
+            {resources.map((resource) => (
+              <Box
+                key={resource.id}
+                margin={{ vertical: 'medium' }}
+                elevation="medium"
+                pad={{ vertical: 'medium', horizontal: 'large' }}
+              >
+                <ManageResourceCard
+                  resource={resource}
+                  options={['edit', 'manage']}
+                  moreOptions={['view', 'archive', 'delete']}
+                  margin={{ bottom: 'large' }}
+                />
+              </Box>
+            ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  )
+}

--- a/client/src/contexts/TeamContext.js
+++ b/client/src/contexts/TeamContext.js
@@ -1,0 +1,35 @@
+import React from 'react'
+
+export const TeamContext = React.createContext({})
+
+export const TeamContextProvider = ({
+  editTeam = {
+    name: '',
+    description: '',
+    members: [],
+    grants: []
+  },
+  children
+}) => {
+  const [team, setTeam] = React.useState(editTeam)
+  const [memberSuggestions, setMemberSuggestions] = React.useState({})
+  const [memberEmail, setMemberEmail] = React.useState('')
+  const [invites, setInvites] = React.useState([])
+
+  return (
+    <TeamContext.Provider
+      value={{
+        team,
+        setTeam,
+        memberSuggestions,
+        setMemberSuggestions,
+        memberEmail,
+        setMemberEmail,
+        invites,
+        setInvites
+      }}
+    >
+      {children}
+    </TeamContext.Provider>
+  )
+}

--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -82,8 +82,6 @@ export default () => {
     return team[attribute]
   }
 
-  const inviteMembers = () => {}
-
   const saveMembers = async (newTeamId) => {
     const teamId = newTeamId || team.id
     const availableMemberIds = (getAttribute('members') || [])
@@ -174,7 +172,6 @@ export default () => {
     getAttribute,
     updateMemberSuggestions,
     memberSuggestions,
-    inviteMembers,
     save,
     addMemberOrInvite,
     memberEmail,

--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -1,20 +1,22 @@
 import React from 'react'
 import { useUser } from 'hooks/useUser'
 import { useAlertsQueue } from 'hooks/useAlertsQueue'
+import { TeamContext } from 'contexts/TeamContext'
 import api from 'api'
 
 export default () => {
   const { addAlert } = useAlertsQueue()
   const { user, token, refreshUser } = useUser()
-  const [team, setTeam] = React.useState({
-    name: '',
-    description: '',
-    members: [],
-    grants: []
-  })
-  const [memberSuggestions, setMemberSuggestions] = React.useState({})
-  const [memberEmail, setMemberEmail] = React.useState('')
-  const [invites, setInvites] = React.useState([])
+  const {
+    team,
+    setTeam,
+    memberSuggestions,
+    setMemberSuggestions,
+    memberEmail,
+    setMemberEmail,
+    invites,
+    setInvites
+  } = React.useContext(TeamContext)
 
   React.useEffect(() => {
     refreshUser()

--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -89,15 +89,14 @@ export default () => {
       .map((m) => m.id)
     const teamRequest = await api.teams.get(teamId, token)
     if (teamRequest.isOk) {
-      const existingMemberIds = teamRequest.response.members
-        .map((m) => m.id)
-        .filter((m) => m !== user.id)
+      const existingMemberIds = teamRequest.response.members.map((m) => m.id)
       const addMemberIds = availableMemberIds.filter(
-        (m) => !existingMemberIds.includes(m.id)
+        (m) => !existingMemberIds.includes(m)
       )
-      const removeMemberIds = existingMemberIds.filter(
-        (memberId) => !availableMemberIds.includes(memberId)
-      )
+      const removeMemberIds = existingMemberIds
+        .filter((m) => !availableMemberIds.includes(m))
+        .filter((m) => m !== user.id)
+
       await Promise.all(
         addMemberIds.map((memberId) => {
           const invitation = {

--- a/client/src/pages/account/teams/[id]/index.js
+++ b/client/src/pages/account/teams/[id]/index.js
@@ -1,32 +1,21 @@
 import React from 'react'
-import { Box, Button, CheckBox, Paragraph, Text, Tabs, Tab } from 'grommet'
+import { Box, Text, Tabs, Tab } from 'grommet'
 import { DrillDownNav } from 'components/DrillDownNav'
-import { ManageResourceCard } from 'components/resources/ManageResourceCard'
-import TeamMembersTable from 'components/TeamMembersTable'
-import { Modal } from 'components/Modal'
 import { Loader } from 'components/Loader'
-import { HeaderRow } from 'components/HeaderRow'
-import Icon from 'components/Icon'
 import useTeamForm from 'hooks/useTeamForm'
+import { TeamContextProvider } from 'contexts/TeamContext'
+import TeamResources from 'components/TeamResources'
+import TeamMembers from 'components/TeamMembers'
+import TeamGrants from 'components/TeamGrants'
 
-const TeamDetail = ({ teamId }) => {
-  const {
-    user,
-    team,
-    fetchTeam,
-    teamFetched,
-    addGrant,
-    removeGrant
-  } = useTeamForm()
-  const [showGrantsModal, setShowGrantsModal] = React.useState(false)
+const TeamDetailContext = ({ teamId }) => {
+  const { team, fetchTeam, teamFetched } = useTeamForm()
 
   React.useEffect(() => {
     if (!teamFetched) fetchTeam(teamId)
   }, [])
 
   if (!teamFetched) return <Loader />
-
-  const { materials: resources, grants = [] } = team
 
   return (
     <DrillDownNav title={team.name} linkBack="/account/teams">
@@ -35,132 +24,24 @@ const TeamDetail = ({ teamId }) => {
       </Box>
       <Tabs>
         <Tab title="Team Resources">
-          <Box pad={{ vertical: 'medium' }}>
-            {resources.length === 0 && (
-              <Text italic color="black-tint-60">
-                You have no resources.
-              </Text>
-            )}
-            {resources.length > 0 && (
-              <>
-                <HeaderRow label={`Resources (${resources.length})`} />
-                <Box margin={{ top: 'medium' }}>
-                  {resources.map((resource) => (
-                    <Box
-                      key={resource.id}
-                      margin={{ vertical: 'medium' }}
-                      elevation="medium"
-                      pad={{ vertical: 'medium', horizontal: 'large' }}
-                    >
-                      <ManageResourceCard
-                        resource={resource}
-                        options={['edit', 'manage']}
-                        moreOptions={['view', 'archive', 'delete']}
-                        margin={{ bottom: 'large' }}
-                      />
-                    </Box>
-                  ))}
-                </Box>
-              </>
-            )}
-          </Box>
+          <TeamResources />
         </Tab>
         <Tab title="Members">
-          <Box pad={{ vertical: 'medium' }}>
-            {team.members.length === 0 && (
-              <Text italic color="black-tint-60">
-                You have no members.
-              </Text>
-            )}
-            <HeaderRow label={`Members (${team.members.length})`} />
-            <TeamMembersTable team={team} />
-          </Box>
+          <TeamMembers />
         </Tab>
         <Tab title="Linked Grants">
-          <Box pad={{ vertical: 'medium' }}>
-            {grants.length === 0 && (
-              <Text italic color="black-tint-60">
-                You have no linked grants.
-              </Text>
-            )}
-            <Button
-              alignSelf="end"
-              primary
-              label="Link Grants"
-              onClick={() => setShowGrantsModal(true)}
-            />
-            <Modal showing={showGrantsModal} setShowing={setShowGrantsModal}>
-              <Box width="large">
-                <Box border={{ side: 'bottom' }} margin={{ bottom: 'medium' }}>
-                  <Text serif size="xlarge">
-                    Link Grants
-                  </Text>
-                </Box>
-                <Text>
-                  Members of your team may only add resources and manage
-                  requests linked with a particular grant. Select the grant(s)
-                  below to associate with this team.
-                </Text>
-                <Text weight="bold" margin={{ vertical: 'medium' }}>
-                  Grants awarded to you (choose as many as appropriate)
-                </Text>
-                {user.grants.length === 0 && (
-                  <Paragraph>You have no grants.</Paragraph>
-                )}
-                {user.grants.map((grant) => (
-                  <CheckBox
-                    key={grant.id}
-                    label={grant.title}
-                    checked={grants.map((g) => g.id).includes(grant.id)}
-                    onChange={async ({ target: { checked } }) => {
-                      if (checked) await addGrant(teamId, grant.id)
-                      if (!checked) await removeGrant(teamId, grant.id)
-                      fetchTeam(teamId)
-                    }}
-                  />
-                ))}
-                <Button
-                  primary
-                  alignSelf="end"
-                  margin={{ vertical: 'medium' }}
-                  label="Done"
-                  onClick={() => {
-                    setShowGrantsModal(false)
-                  }}
-                />
-              </Box>
-            </Modal>
-            {grants.length > 0 && (
-              <>
-                <HeaderRow label={`Grants (${grants.length})`} />
-                {grants.map(({ title, funder_id: funderId, id }) => (
-                  <Box key={funderId} direction="row" justify="between">
-                    <Box direction="row" align="center">
-                      <Icon color="plain" name="Grant" />
-                      <Box pad={{ left: 'small' }}>
-                        <Paragraph margin="none">{title}</Paragraph>
-                        <Paragraph size="small">Grant ID:{funderId}</Paragraph>
-                      </Box>
-                    </Box>
-                    <Button
-                      plain
-                      size="small"
-                      color="error"
-                      icon={<Icon name="Trashcan" color="error" size="small" />}
-                      label="Remove"
-                      onClick={async () => {
-                        await removeGrant(teamId, id)
-                        fetchTeam(teamId)
-                      }}
-                    />
-                  </Box>
-                ))}
-              </>
-            )}
-          </Box>
+          <TeamGrants />
         </Tab>
       </Tabs>
     </DrillDownNav>
+  )
+}
+
+const TeamDetail = ({ teamId }) => {
+  return (
+    <TeamContextProvider>
+      <TeamDetailContext teamId={teamId} />
+    </TeamContextProvider>
   )
 }
 

--- a/client/src/pages/account/teams/create.js
+++ b/client/src/pages/account/teams/create.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
 import { DrillDownNav } from 'components/DrillDownNav'
+import { TeamContextProvider } from 'contexts/TeamContext'
 
 const TeamForm = dynamic(() => import('components/TeamForm'), { ssr: false })
 
 const TeamCreate = () => {
   return (
     <DrillDownNav title="Create Team" linkBack="/account/teams">
-      <TeamForm />
+      <TeamContextProvider>
+        <TeamForm />
+      </TeamContextProvider>
     </DrillDownNav>
   )
 }


### PR DESCRIPTION
## Issue Number

#459 

## Purpose/Implementation Notes

This pr makes adding team members functional but wont be able to match designs until we implement the tokenized invites with the API

* creates a team context to help passing data between team form components
* wraps the create and detail team pages in the Team Context
* puts the team detail tab contents into their own files
* adds the `Add Members` modal on the team detail page
* fixes a bug in the update where the owners was being invited twice instead of 0 times
* adds the api function for updating a team

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A tested on create team page and then updated with both existing members and invited (email-only) members

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2020-09-29 at 12 43 58 PM](https://user-images.githubusercontent.com/1075609/94588072-7399d500-0251-11eb-9083-87d56b8235b7.png)

