### PR TITLE
Fix the pretty date function to pluralize correctly and to only have int values

### DIFF
--- a/api/resources_portal/utils.py
+++ b/api/resources_portal/utils.py
@@ -28,21 +28,25 @@ def pretty_date(time=False):
         if second_diff < 10:
             return "just now"
         if second_diff < 60:
-            return str(second_diff) + " seconds ago"
+            return str(int(second_diff)) + " seconds ago"
         if second_diff < 120:
             return "a minute ago"
         if second_diff < 3600:
-            return str(second_diff / 60) + " minutes ago"
+            return str(int(second_diff / 60)) + " minutes ago"
         if second_diff < 7200:
             return "an hour ago"
         if second_diff < 86400:
-            return str(second_diff / 3600) + " hours ago"
+            return str(int(second_diff / 3600)) + " hours ago"
     if day_diff == 1:
         return "Yesterday"
     if day_diff < 7:
         return str(day_diff) + " days ago"
+    if day_diff < 14:
+        return "a week ago"
     if day_diff < 31:
-        return str(day_diff / 7) + " weeks ago"
+        return str(int(day_diff / 7)) + " weeks ago"
+    if day_diff < 61:
+        return "a month ago"
     if day_diff < 365:
-        return str(day_diff / 30) + " months ago"
-    return str(day_diff / 365) + " years ago"
+        return str(int(day_diff / 30)) + " months ago"
+    return str(int(day_diff / 365)) + " years ago"


### PR DESCRIPTION
## Issue Number

N/A David reported it

## Purpose/Implementation Notes

We were seeing things like: `human_readable_created_at: "2.6527777777777777 hours ago"`

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added unit tests!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
