### PR TITLE
User.addresses now filters out unsaved addresses.

### DIFF
--- a/api/resources_portal/test/views/test_user.py
+++ b/api/resources_portal/test/views/test_user.py
@@ -131,7 +131,7 @@ class TestUserDetailTestCase(APITestCase):
         for field in PRIVATE_FIELDS:
             self.assertIn(field, response_json)
 
-        self.assertEqual(len(response_json["addresses"]), 2)
+        self.assertEqual(len(response_json["addresses"]), 1)
 
     def test_get_request_from_unauthenticated_user_forbidden(self):
         self.client.force_authenticate(user=None)

--- a/api/resources_portal/views/address.py
+++ b/api/resources_portal/views/address.py
@@ -31,14 +31,6 @@ class AddressSerializer(serializers.ModelSerializer):
         read_only_fields = ("id", "created_at", "updated_at", "user")
 
 
-class SavedAddressSerializer(AddressSerializer):
-    def to_representation(self, data):
-        if data.saved_for_reuse:
-            return super(AddressSerializer, self).to_representation(data)
-        else:
-            return None
-
-
 class AddressDetailSerializer(AddressSerializer):
     user = UserRelationSerializer(read_only=True)
 

--- a/api/resources_portal/views/user.py
+++ b/api/resources_portal/views/user.py
@@ -18,7 +18,7 @@ from resources_portal.serializers import (
     OrganizationInvitationRelationSerializer,
     OrganizationRelationSerializer,
 )
-from resources_portal.views.address import SavedAddressSerializer
+from resources_portal.views.address import AddressSerializer
 
 logger = get_and_configure_logger(__name__)
 
@@ -99,7 +99,12 @@ class UserSerializer(serializers.ModelSerializer):
     grants = GrantRelationSerializer(many=True, read_only=True)
     assignments = MaterialRequestRelationSerializer(many=True, read_only=True)
     invitations = OrganizationInvitationRelationSerializer(many=True, read_only=True)
-    addresses = SavedAddressSerializer(many=True, read_only=True)
+    addresses = serializers.SerializerMethodField()
+
+    def get_addresses(self, obj):
+        queryset = obj.addresses.filter(saved_for_reuse=True)
+
+        return AddressSerializer(queryset, many=True, read_only=True).data
 
     def to_representation(self, request_data):
         # get the original representation


### PR DESCRIPTION
## Issue Number

#461 

## Purpose/Implementation Notes

Addresses that weren't saved for reuse were being returned as `None` instead of being filtered out.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

There was a unit test that was testing that this wasn't working. When I fixed the issue the test broke and now I fixed the test.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
