### PR TITLE
Filter materials on org id and speed up tests

### DIFF
--- a/api/resources_portal/test/views/test_material.py
+++ b/api/resources_portal/test/views/test_material.py
@@ -88,6 +88,11 @@ class TestMaterialListTestCase(APITestCase):
 
         self.assertEqual(len(response.json()["results"]), 1)
 
+        response = self.client.get(self.url + "?organization__id=10")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.json()["results"]), 1)
+
 
 class TestSingleMaterialTestCase(APITestCase):
     """

--- a/api/resources_portal/test/views/test_material.py
+++ b/api/resources_portal/test/views/test_material.py
@@ -77,7 +77,7 @@ class TestMaterialListTestCase(APITestCase):
 
     def test_get_request_filter_succeeds(self):
         for i in range(11):
-            MaterialFactory(category="CELL_LINE")
+            last_material = MaterialFactory(category="CELL_LINE")
 
         self.client.force_authenticate(user=None)
 
@@ -91,7 +91,8 @@ class TestMaterialListTestCase(APITestCase):
 
         self.assertEqual(len(response.json()["results"]), 1)
 
-        response = self.client.get(self.url + "?organization__id=10")
+        last_org_id = last_material.organization.id
+        response = self.client.get(self.url + f"?organization__id={last_org_id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.assertEqual(len(response.json()["results"]), 1)

--- a/api/resources_portal/test/views/test_material.py
+++ b/api/resources_portal/test/views/test_material.py
@@ -34,10 +34,6 @@ class TestMaterialListTestCase(APITestCase):
         )
         self.material_data = model_to_dict(self.material)
 
-        # Create a bunch for listing
-        for i in range(20):
-            MaterialFactory(category="CELL_LINE")
-
     def test_post_request_with_no_data_fails(self):
         self.client.force_authenticate(user=self.user)
         response = self.client.post(self.url, {})
@@ -70,6 +66,9 @@ class TestMaterialListTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_request_limit_succeeds(self):
+        for i in range(4):
+            MaterialFactory(category="CELL_LINE")
+
         self.client.force_authenticate(user=None)
         response = self.client.get(self.url + "?limit=3")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -77,7 +76,11 @@ class TestMaterialListTestCase(APITestCase):
         self.assertEqual(len(response.json()["results"]), 3)
 
     def test_get_request_filter_succeeds(self):
+        for i in range(11):
+            MaterialFactory(category="CELL_LINE")
+
         self.client.force_authenticate(user=None)
+
         response = self.client.get(self.url + "?category=CELL_LINE")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/api/resources_portal/views/material.py
+++ b/api/resources_portal/views/material.py
@@ -43,6 +43,7 @@ class MaterialViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         "imported",
         "import_source",
         "pre_print_doi",
+        "organization__id",
     )
 
     def get_serializer_class(self):


### PR DESCRIPTION
## Issue Number

N/A David just pointed it out

## Purpose/Implementation Notes

Materials should be filterable by organization id.

I also realized that the material view tests were super duper slow cause we created a ton of database objets.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added a unit test, and they go WAAAAYYYYYY faster for the materials view:

> Ran 26 tests in 161.766s

to

> Ran 26 tests in 36.859s

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
