### PR TITLE
Make embeded images default to empty list instead of None.

### DIFF
--- a/api/resources_portal/emailer.py
+++ b/api/resources_portal/emailer.py
@@ -99,7 +99,7 @@ def send_mail(
     title: str,
     text: str = None,
     html: str = None,
-    embedded_images: list = None,
+    embedded_images: list = [],
 ) -> dict:
     """
     Send email to recipients. Sends one mail to all recipients.


### PR DESCRIPTION
## Issue Number

#503 

## Purpose/Implementation Notes

The error was:
```
2020-10-08T13:44:57.192-04:00 | for embedded_image in embedded_images:
2020-10-08T13:44:57.192-04:00 | TypeError: 'NoneType' object is not iterable

```

This doesn't get tested in unit tests because we can't actually send mail without being deployed.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I can't really without staging.
