### PR TITLE
if user id isnt set logout user

### DIFF
--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -8,6 +8,7 @@ export const useUser = (defaultUser, defaultToken) => {
   )
 
   React.useEffect(() => {
+    if ((!user || !user.id) && token) logOut()
     if (defaultUser && defaultToken) {
       setUser(defaultUser)
       setToken(defaultToken)


### PR DESCRIPTION
## Issue Number

n/a 

I'm seeing issues in sentry that user.id isnt defined. this should help recover browsers that have bad localstorage issues.