### PR TITLE
adds protocol_doi to response additional_metadata

### DIFF
--- a/api/resources_portal/views/import_materials.py
+++ b/api/resources_portal/views/import_materials.py
@@ -81,6 +81,7 @@ def import_protocol(protocol_doi, user):
     additional_metadata = {
         "protocol_name": metadata["protocol_name"],
         "description": metadata["description"],
+        "protocol_doi": protocol_doi,
         # There's no abstract to import.
         "abstract": "",
     }


### PR DESCRIPTION
## Issue Number

#472 

## Purpose/Implementation Notes

This allows the protocol to be edited after import it wasnt defined in the response so it was lost and the component's logic determined that it wasnt imported yet when showing the form step.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
