### PR TITLE
471 link imported to source

### DIFF
--- a/client/src/components/RequestButton.js
+++ b/client/src/components/RequestButton.js
@@ -3,22 +3,34 @@ import { Button } from 'grommet'
 import Link from 'next/link'
 import { CreateAccountLoginButton } from 'components/CreateAccountLoginButton'
 import { useUser } from 'hooks/useUser'
+import { getReadable } from 'helpers/readableNames'
 
 export const RequestButton = ({ resource }) => {
   const { isLoggedIn } = useUser()
 
-  if (isLoggedIn) {
-    return (
-      <Link
-        href="/resources/[id]/request"
-        as={`/resources/${resource.id}/request`}
-      >
-        <Button label="Request" primary />
-      </Link>
-    )
-  }
+  const requestLink = resource.imported
+    ? resource.url
+    : `/resources/${resource.id}/request`
 
-  return <CreateAccountLoginButton title="Sign in to Request" plainButton />
+  if (!isLoggedIn)
+    return <CreateAccountLoginButton title="Sign in to Request" plainButton />
+
+  return resource.imported ? (
+    <Button
+      as="a"
+      href={requestLink}
+      target="_blank"
+      label={`Request on ${
+        getReadable(resource.import_source) || 'Source Site'
+      }`}
+      margin={{ bottom: 'small' }}
+      primary
+    />
+  ) : (
+    <Link href={requestLink}>
+      <Button as="a" href={requestLink} label="Request" primary />
+    </Link>
+  )
 }
 
 export default RequestButton

--- a/client/src/pages/resources/[id]/index.js
+++ b/client/src/pages/resources/[id]/index.js
@@ -21,7 +21,7 @@ const ResourceDetailsPage = ({ resource }) => {
       </Text>
     )
   return (
-    <>
+    <Box margin={{ bottom: 'xlarge' }}>
       <Box
         direction="row"
         justify="between"
@@ -46,14 +46,16 @@ const ResourceDetailsPage = ({ resource }) => {
             <TabHeading title="Contact Submitter" />
             <ContactSubmitter resource={resource} />
           </Tab>
-          <Tab title="Request Requirements">
-            <TabHeading title="Request Requirements" />
-            <RequestRequirements resource={resource} />
-          </Tab>
+          {!resource.imported && (
+            <Tab title="Request Requirements">
+              <TabHeading title="Request Requirements" />
+              <RequestRequirements resource={resource} />
+            </Tab>
+          )}
         </Tabs>
       </Box>
       <RelatedResources resource={resource} />
-    </>
+    </Box>
   )
 }
 


### PR DESCRIPTION
## Issue Number

#471 

## Purpose/Implementation Notes

* hides the tab for request requirements for imported resources (will always be empty anyway)
* `RequestButton` component should show the request on source button when imported and link there

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/a tests with imported and listed resources

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2020-10-17 at 12 27 23 PM](https://user-images.githubusercontent.com/1075609/96348080-1f298e80-1074-11eb-8a30-f09dacff2e87.png)

