### PR TITLE
556 archive and delete resource from dropdown button then modal

### DIFF
--- a/client/src/components/resources/ListResourceForm.js
+++ b/client/src/components/resources/ListResourceForm.js
@@ -27,7 +27,9 @@ export default ({ defaultStep = -1 }) => {
     validateShippingRequirement,
     resource,
     save,
-    clearResourceContext
+    clearResourceContext,
+    getAttribute,
+    setAttribute
   } = useResourceForm()
 
   const loadedRef = React.useRef(false)
@@ -42,6 +44,10 @@ export default ({ defaultStep = -1 }) => {
       setStep(0)
       loadedRef.current = true
     }
+
+    // force not imported
+    if (resource && getAttribute('imported') === undefined)
+      setAttribute('imported', false)
 
     if (savedResource) {
       clearResourceContext()

--- a/client/src/components/resources/ManageResourceCard.js
+++ b/client/src/components/resources/ManageResourceCard.js
@@ -14,12 +14,10 @@ export const ManageOptions = ({
   direction,
   pad = 'none',
   openRequests,
-  onChange
+  onModalOpen = () => {},
+  setShowArchive,
+  setShowDelete
 }) => {
-  const { token } = useUser()
-  const { addAlert } = useAlertsQueue()
-  const [showDelete, setShowDelete] = React.useState(false)
-  const [showArchive, setShowArchive] = React.useState(false)
   const manageLink = `/account/manage-resources/${resource.id}`
   const editLink = `/resources/${resource.id}/edit`
   const viewResourceLink = `resources/${resource.id}`
@@ -58,133 +56,24 @@ export const ManageOptions = ({
           <Anchor
             icon={<Icon name="Archive" size="small" />}
             label="Archive"
-            onClick={() => setShowArchive(true)}
+            onClick={() => {
+              setShowArchive(true)
+              onModalOpen()
+            }}
           />
-          <Modal showing={showArchive} setShowing={setShowArchive}>
-            <>
-              {openRequests === 0 && (
-                <Box>
-                  <Box direction="row">
-                    <Icon name="Warning" color="warning" />
-                    <Text>Are you sure you want to archive this resource?</Text>
-                  </Box>
-                  <Box>
-                    <Text>
-                      Researchers will not be able to request for this resource
-                      but they will still be able to review it.
-                    </Text>
-                  </Box>
-                  <Box>
-                    <Button
-                      label="Cancel"
-                      onClick={() => setShowArchive(false)}
-                    />
-                    <Button
-                      primary
-                      label="Archive Resource"
-                      onClick={async () => {
-                        const archiveRequest = await api.resources.update(
-                          resource.id,
-                          { is_archived: true },
-                          token
-                        )
-                        if (archiveRequest.isOk) {
-                          onChange()
-                        } else {
-                          addAlert('Unable to archive resource', 'error')
-                        }
-                      }}
-                    />
-                  </Box>
-                </Box>
-              )}
-              {openRequests !== 0 && (
-                <Box>
-                  <Box direction="row">
-                    <Icon name="Warning" color="warning" />
-                    <Text>Cannot archive resource with open requests.</Text>
-                  </Box>
-                  <Box>
-                    <Text>
-                      Your resource has{' '}
-                      <Link href={viewResourceLink}>
-                        <Anchor
-                          label={`${openRequests} open requests`}
-                          href={viewResourceLink}
-                        />
-                      </Link>
-                      {'. '}
-                      Please accept or reject those requests before archiving
-                      this resource.
-                    </Text>
-                  </Box>
-                  <Box>
-                    <Link href={viewResourceLink}>
-                      <Button
-                        as="a"
-                        label="Show Requests"
-                        href={viewResourceLink}
-                      />
-                    </Link>
-                  </Box>
-                </Box>
-              )}
-            </>
-          </Modal>
         </>
       )}
       {options.includes('delete') && (
-        <>
-          <Anchor
-            icon={<Icon name="Trashcan" size="small" color="error" />}
-            color="error"
-            label="Delete"
-            onClick={() => setShowDelete(true)}
-            disabled={openRequests > 0}
-          />
-          <Modal showing={showDelete} setShowing={setShowDelete}>
-            <>
-              <Box
-                border={{
-                  side: 'bottom',
-                  color: 'border-black',
-                  size: 'small'
-                }}
-              >
-                <Text size="large" color="error">
-                  Delete Resource
-                </Text>
-              </Box>
-              <Box>
-                <Text>Are you sure you want to delete this resource?</Text>
-                <Text>{resource.title}</Text>
-                <Box>
-                  <Box>
-                    <Button
-                      label="Cancel"
-                      onClick={() => setShowDelete(false)}
-                    />
-                    <Button
-                      background="error"
-                      label="Delete Resource"
-                      onClick={async () => {
-                        const deleteRequest = await api.resources.delete(
-                          resource.id,
-                          token
-                        )
-                        if (deleteRequest.isOk) {
-                          if (onChange) onChange()
-                        } else {
-                          addAlert('Unable to delete resource', 'error')
-                        }
-                      }}
-                    />
-                  </Box>
-                </Box>
-              </Box>
-            </>
-          </Modal>
-        </>
+        <Anchor
+          icon={<Icon name="Trashcan" size="small" color="error" />}
+          color="error"
+          label="Delete"
+          onClick={() => {
+            setShowDelete(true)
+            onModalOpen()
+          }}
+          disabled={openRequests > 0}
+        />
       )}
     </Box>
   )
@@ -194,14 +83,26 @@ export const ManageResourceCard = ({
   resource,
   options = [],
   moreOptions = [],
-  onChange
+  onChange = () => {}
 }) => {
   const { token, getTeam, isPersonalResource } = useUser()
   const manageLink = `/account/manage-resources/${resource.id}`
   const team = getTeam(resource.organization)
   const teamLink = `/account/teams/${team.id}`
+  const viewResourceLink = `resources/${resource.id}`
 
   const [openRequests, setOpenRequests] = React.useState()
+  const [dropOpen, setDropOpen] = React.useState(false)
+
+  const { addAlert } = useAlertsQueue()
+  const [showDelete, setShowDelete] = React.useState(false)
+  const [showArchive, setShowArchive] = React.useState(false)
+  const archiveText = resource.is_archived
+    ? 'Un-Archive Resource'
+    : 'Archive Resource'
+  const archivedMessage = resource.is_archived
+    ? 'Resource Un-Archived'
+    : 'Resource Archived'
 
   React.useState(() => {
     const fetchRequests = async () => {
@@ -224,6 +125,9 @@ export const ManageResourceCard = ({
       options={moreOptions}
       openRequests={openRequests}
       onChange={onChange}
+      onModalOpen={() => setDropOpen(false)}
+      setShowDelete={setShowDelete}
+      setShowArchive={setShowArchive}
     />
   )
 
@@ -241,6 +145,9 @@ export const ManageResourceCard = ({
           {moreOptions.length > 0 && (
             <DropButton
               plain
+              open={dropOpen}
+              onOpen={() => setDropOpen(true)}
+              onClose={() => setDropOpen(false)}
               icon={<Icon name="MoreOptions" size="small" />}
               label="More Options"
               dropAlign={{ top: 'bottom' }}
@@ -277,7 +184,18 @@ export const ManageResourceCard = ({
         ) : (
           <Text>0 Open Requests</Text>
         )}
-        {!resource.is_archived && (
+        {resource.is_archived ? (
+          <>
+            <Box
+              background="brand"
+              round
+              width="8px"
+              height="8px"
+              margin="small"
+            />
+            <Text italic>Archived</Text>
+          </>
+        ) : (
           <>
             <Box
               background="brand"
@@ -290,6 +208,124 @@ export const ManageResourceCard = ({
           </>
         )}
       </Box>
+      <Modal showing={showArchive} setShowing={setShowArchive}>
+        <>
+          {openRequests === 0 && (
+            <Box>
+              <Box direction="row">
+                <Icon name="Warning" color="warning" />
+                {resource.is_archived ? (
+                  <Text>
+                    Are you sure you want to un-archive this resource?
+                  </Text>
+                ) : (
+                  <Text>Are you sure you want to archive this resource?</Text>
+                )}
+              </Box>
+              <Box>
+                <Text>
+                  Researchers will not be able to request for this resource but
+                  they will still be able to review it.
+                </Text>
+              </Box>
+              <Box direction="row" pad="medium" justify="end" gap="medium">
+                <Button label="Cancel" onClick={() => setShowArchive(false)} />
+                <Button
+                  primary
+                  label={archiveText}
+                  onClick={async () => {
+                    const archiveRequest = await api.resources.update(
+                      resource.id,
+                      { ...resource, is_archived: !resource.is_archived },
+                      token
+                    )
+                    if (archiveRequest.isOk) {
+                      onChange()
+                      addAlert(archivedMessage, 'success')
+                      setShowArchive(false)
+                    } else {
+                      addAlert('Unable to archive resource', 'error')
+                    }
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+          {openRequests !== 0 && (
+            <Box>
+              <Box direction="row">
+                <Icon name="Warning" color="warning" />
+                <Text>Cannot archive resource with open requests.</Text>
+              </Box>
+              <Box>
+                <Text>
+                  Your resource has{' '}
+                  <Link href={viewResourceLink}>
+                    <Anchor
+                      label={`${openRequests} open requests`}
+                      href={viewResourceLink}
+                    />
+                  </Link>
+                  {'. '}
+                  Please accept or reject those requests before archiving this
+                  resource.
+                </Text>
+              </Box>
+              <Box>
+                <Link href={viewResourceLink}>
+                  <Button
+                    as="a"
+                    label="Show Requests"
+                    href={viewResourceLink}
+                  />
+                </Link>
+              </Box>
+            </Box>
+          )}
+        </>
+      </Modal>
+
+      <Modal showing={showDelete} setShowing={setShowDelete}>
+        <>
+          <Box
+            border={{
+              side: 'bottom',
+              color: 'border-black',
+              size: 'small'
+            }}
+          >
+            <Text size="large" color="error">
+              Delete Resource
+            </Text>
+          </Box>
+          <Box>
+            <Text>Are you sure you want to delete this resource?</Text>
+            <Text>{resource.title}</Text>
+            <Box>
+              <Box direction="row" pad="medium" justify="end" gap="medium">
+                <Button label="Cancel" onClick={() => setShowDelete(false)} />
+                <Button
+                  critical
+                  label="Delete Resource"
+                  onClick={async () => {
+                    const deleteRequest = await api.resources.delete(
+                      resource.id,
+                      token
+                    )
+                    if (deleteRequest.isOk) {
+                      if (onChange) onChange()
+                      addAlert('Resource Deleted', 'success')
+                      setShowDelete(false)
+                    } else {
+                      addAlert('Unable to delete resource', 'error')
+                    }
+                  }}
+                />
+              </Box>
+            </Box>
+          </Box>
+        </>
+      </Modal>
     </Box>
   )
 }

--- a/client/src/hooks/useResourceForm.js
+++ b/client/src/hooks/useResourceForm.js
@@ -344,6 +344,8 @@ export default () => {
     if (isOk) {
       await saveSequenceMaps(savedResource)
       await saveGrants(savedResource)
+    } else {
+      return {}
     }
 
     // should optionally set the resource here from the saved version

--- a/client/src/pages/account/manage-resources/index.js
+++ b/client/src/pages/account/manage-resources/index.js
@@ -11,6 +11,7 @@ import EmptyManageResources from '../../../images/empty-manage-resources.svg'
 const ManageResources = () => {
   const { user, token } = useUser()
   const [resources, setResources] = React.useState(false)
+  const [refresh, setRefresh] = React.useState(false)
 
   React.useEffect(() => {
     const asyncResourceFetch = async () => {
@@ -25,10 +26,11 @@ const ManageResources = () => {
         return []
       })
 
+      setRefresh(false)
       setResources([].concat(...fetchedResources))
     }
 
-    if (!resources) asyncResourceFetch()
+    if (!resources || refresh) asyncResourceFetch()
   })
 
   return (
@@ -55,6 +57,7 @@ const ManageResources = () => {
               resource={resource}
               options={['edit', 'manage']}
               moreOptions={['view', 'archive', 'delete']}
+              onChange={() => setRefresh(true)}
             />
           </Box>
         ))}


### PR DESCRIPTION
## Issue Number

#556 

## Purpose/Implementation Notes

I thought this issue was limited to using the incorrect api function.
turns out the modal was being dismissed before the button was being pressed because the modal was nested inside of the dropdown button. This PR moves that outside and toggles the button dropdown manually after a modal link is clicked.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a tested archiving and deleting resources

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

n/a
