### PR TITLE
Reorder the parts of the emails to put html last.

### DIFF
--- a/api/resources_portal/emailer.py
+++ b/api/resources_portal/emailer.py
@@ -75,15 +75,6 @@ def create_multipart_message(
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
 
-    # Record the MIME types of both parts - text/plain and text/html.
-    # According to RFC 2046, the last part of a multipart message, in this case the HTML message, is best and preferred.
-    if text:
-        part = MIMEText(text, "plain")
-        msg.attach(part)
-    if html:
-        part = MIMEText(html, "html")
-        msg.attach(part)
-
     for embedded_image in embedded_images:
         with open(embedded_image["file_path"], "rb") as f:
             image_part = MIMEImage(f.read(), embedded_image["subtype"])
@@ -93,6 +84,15 @@ def create_multipart_message(
             "Content-Disposition", "inline", filename=os.path.basename(embedded_image["file_path"])
         )
         msg.attach(image_part)
+
+    # Record the MIME types of both parts - text/plain and text/html.
+    # According to RFC 2046, the last part of a multipart message, in this case the HTML message, is best and preferred.
+    if text:
+        part = MIMEText(text, "plain")
+        msg.attach(part)
+    if html:
+        part = MIMEText(html, "html")
+        msg.attach(part)
 
     return msg
 


### PR DESCRIPTION
## Issue Number

#526 

## Purpose/Implementation Notes

from https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
```
The multipart/alternative type is syntactically identical to multipart/mixed, but the semantics are different. In particular, each of the parts is an "alternative" version of the same information. User agents should recognize that the content of the various parts are interchangeable. The user agent should either choose the "best" type based on the user's environment and preferences, or offer the user the available alternatives. In general, choosing the best type means displaying only the LAST part that can be displayed. This may be used, for example, to send mail in a fancy text format in such a way that it can easily be displayed anywhere:
...
```

This puts HTML last so it gets displayed instead of just an image.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Needs staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
