### PR TITLE
Refactors material_request update function so notifications have the right targets.

### DIFF
--- a/api/resources_portal/test/views/test_material_request.py
+++ b/api/resources_portal/test/views/test_material_request.py
@@ -394,10 +394,12 @@ class TestSingleMaterialRequestTestCase(APITestCase):
         updated_request = MaterialRequest.objects.get(id=self.request.id)
         self.assertEqual(updated_request.assigned_to, self.other_member)
 
-        self.assertEqual(
-            len(Notification.objects.filter(notification_type="MATERIAL_REQUEST_SHARER_ASSIGNED")),
-            1,
+        personal_notifications = Notification.objects.filter(
+            notification_type="MATERIAL_REQUEST_SHARER_ASSIGNED"
         )
+        self.assertEqual(personal_notifications[0].associated_user, self.other_member)
+        self.assertEqual(personal_notifications.count(), 1)
+
         self.assertEqual(
             len(
                 Notification.objects.filter(notification_type="MATERIAL_REQUEST_SHARER_ASSIGNMENT")

--- a/api/resources_portal/views/material_request.py
+++ b/api/resources_portal/views/material_request.py
@@ -220,27 +220,27 @@ def notify_sharer(notification_type, request):
     )
 
 
-def notify_request_status_change(status, request):
-    if status == "APPROVED":
+def notify_request_status_change(request):
+    if request.status == "APPROVED":
         notify_requester("MATERIAL_REQUEST_REQUESTER_ACCEPTED", request)
         notify_sharer("MATERIAL_REQUEST_SHARER_APPROVED", request)
-    elif status == "REJECTED":
+    elif request.status == "REJECTED":
         notify_requester("MATERIAL_REQUEST_REQUESTER_REJECTED", request)
         notify_sharer("MATERIAL_REQUEST_SHARER_REJECTED", request)
-    elif status == "CANCELLED":
+    elif request.status == "CANCELLED":
         notify_requester("MATERIAL_REQUEST_REQUESTER_CANCELLED", request)
         notify_sharer("MATERIAL_REQUEST_SHARER_CANCELLED", request)
-    elif status == "FULFILLED":
+    elif request.status == "FULFILLED":
         notify_requester("MATERIAL_REQUEST_REQUESTER_FULFILLED", request)
         notify_sharer("MATERIAL_REQUEST_SHARER_FULFILLED", request)
-    elif status == "IN_FULFILLMENT":
+    elif request.status == "IN_FULFILLMENT":
         if request.executed_mta_attachment:
             notify_sharer("MATERIAL_REQUEST_SHARER_EXECUTED_MTA", request)
             notify_requester("MATERIAL_REQUEST_REQUESTER_EXECUTED_MTA", request)
         else:
             notify_sharer("MATERIAL_REQUEST_SHARER_IN_FULFILLMENT", request)
             notify_requester("MATERIAL_REQUEST_REQUESTER_IN_FULFILLMENT", request)
-    elif status == "VERIFIED_FULFILLED":
+    elif request.status == "VERIFIED_FULFILLED":
         notify_sharer("MATERIAL_REQUEST_SHARER_VERIFIED", request)
     else:
         return
@@ -251,6 +251,12 @@ def user_in_attachment_org(attachment, user):
         return user in attachment.owned_by_org.members.all()
     else:
         return False
+
+
+def field_changed(field_name, old_material_request, new_material_request):
+    new_value = getattr(new_material_request, field_name)
+    old_value = getattr(old_material_request, field_name)
+    return new_value != old_value
 
 
 def add_attachment_to_material_request(material_request, attachment, attachment_type, user):
@@ -381,80 +387,85 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
 
         return Response(data=model_to_dict(material_request), status=201)
 
-    def create_notifications(self, request, material_request, serializer):
-        def field_changed(field_name):
-            return field_name in request.data and serializer.validated_data[field_name] != getattr(
-                material_request, field_name
-            )
+    def create_notifications(self, request, old_material_request, new_material_request):
+        if field_changed("status", old_material_request, new_material_request):
+            notify_request_status_change(new_material_request)
 
-        if field_changed("status"):
-            notify_request_status_change(serializer.validated_data["status"], material_request)
-
-        if request.user == material_request.requester:
-            if field_changed("requester_signed_mta_attachment"):
-                notify_sharer("MATERIAL_REQUEST_SHARER_RECEIVED_MTA", material_request)
-            elif (
-                field_changed("payment_method")
-                or field_changed("payment_method_notes")
-                or field_changed("address")
-                or field_changed("irb_attachment")
+        if request.user == new_material_request.requester:
+            if field_changed(
+                "requester_signed_mta_attachment", old_material_request, new_material_request
             ):
-                notify_sharer("MATERIAL_REQUEST_SHARER_RECEIVED_INFO", material_request)
+                notify_sharer("MATERIAL_REQUEST_SHARER_RECEIVED_MTA", new_material_request)
+            elif (
+                field_changed("payment_method", old_material_request, new_material_request)
+                or field_changed("payment_method_notes", old_material_request, new_material_request)
+                or field_changed("address", old_material_request, new_material_request)
+                or field_changed("irb_attachment", old_material_request, new_material_request)
+            ):
+                notify_sharer("MATERIAL_REQUEST_SHARER_RECEIVED_INFO", new_material_request)
 
         else:
-            if field_changed("executed_mta_attachment"):
-                notify_requester("MATERIAL_REQUEST_REQUESTER_EXECUTED_MTA", material_request)
-                notify_sharer("MATERIAL_REQUEST_SHARER_EXECUTED_MTA", material_request)
+            if field_changed("executed_mta_attachment", old_material_request, new_material_request):
+                notify_requester("MATERIAL_REQUEST_REQUESTER_EXECUTED_MTA", new_material_request)
+                notify_sharer("MATERIAL_REQUEST_SHARER_EXECUTED_MTA", new_material_request)
 
-            if field_changed("assigned_to"):
-                notify_sharer("MATERIAL_REQUEST_SHARER_ASSIGNED", material_request)
-                notify_sharer("MATERIAL_REQUEST_SHARER_ASSIGNMENT", material_request)
+            if field_changed("assigned_to", old_material_request, new_material_request):
+                notify_sharer("MATERIAL_REQUEST_SHARER_ASSIGNED", new_material_request)
+                notify_sharer("MATERIAL_REQUEST_SHARER_ASSIGNMENT", new_material_request)
 
-    def create_events(self, request, material_request, serializer):
-        material = material_request.material
-
-        def field_changed(field_name):
-            return field_name in request.data and serializer.validated_data[field_name] != getattr(
-                material_request, field_name
-            )
+    def create_events(self, request, old_material_request, new_material_request):
+        material = old_material_request.material
 
         def create_event(event_type, material, created_by, assigned_to):
             MaterialShareEvent(
                 event_type=event_type,
                 material=material,
-                material_request=material_request,
+                material_request=new_material_request,
                 created_by=created_by,
                 assigned_to=assigned_to,
             ).save()
 
-        if "assigned_to" in serializer.validated_data:
-            assigned_to = serializer.validated_data["assigned_to"]
-        else:
-            assigned_to = material_request.assigned_to
-
-        if field_changed("assigned_to"):
-            create_event("REQUEST_REASSIGNED", material, request.user, assigned_to)
-
-        if field_changed("status"):
-            event_type = "REQUEST_" + serializer.validated_data["status"]
-            create_event(event_type, material, request.user, assigned_to)
-
-        if field_changed("irb_attachment"):
-            create_event("REQUESTER_IRB_ADDED", material, request.user, assigned_to)
-
-        if field_changed("requester_signed_mta_attachment"):
-            create_event("REQUESTER_MTA_ADDED", material, request.user, assigned_to)
-
-        if field_changed("payment_method"):
-            create_event("REQUESTER_PAYMENT_METHOD_ADDED", material, request.user, assigned_to)
-
-        if field_changed("payment_method_notes"):
+        if field_changed("assigned_to", old_material_request, new_material_request):
             create_event(
-                "REQUESTER_PAYMENT_METHOD_NOTES_ADDED", material, request.user, assigned_to
+                "REQUEST_REASSIGNED", material, request.user, new_material_request.assigned_to
             )
 
-        if field_changed("executed_mta_attachment"):
-            create_event("SHARER_MTA_ADDED", material, request.user, assigned_to)
+        if field_changed("status", old_material_request, new_material_request):
+            event_type = "REQUEST_" + new_material_request.status
+            create_event(event_type, material, request.user, new_material_request.assigned_to)
+
+        if field_changed("irb_attachment", old_material_request, new_material_request):
+            create_event(
+                "REQUESTER_IRB_ADDED", material, request.user, new_material_request.assigned_to
+            )
+
+        if field_changed(
+            "requester_signed_mta_attachment", old_material_request, new_material_request
+        ):
+            create_event(
+                "REQUESTER_MTA_ADDED", material, request.user, new_material_request.assigned_to
+            )
+
+        if field_changed("payment_method", old_material_request, new_material_request):
+            create_event(
+                "REQUESTER_PAYMENT_METHOD_ADDED",
+                material,
+                request.user,
+                new_material_request.assigned_to,
+            )
+
+        if field_changed("payment_method_notes", old_material_request, new_material_request):
+            create_event(
+                "REQUESTER_PAYMENT_METHOD_NOTES_ADDED",
+                material,
+                request.user,
+                new_material_request.assigned_to,
+            )
+
+        if field_changed("executed_mta_attachment", old_material_request, new_material_request):
+            create_event(
+                "SHARER_MTA_ADDED", material, request.user, new_material_request.assigned_to
+            )
 
     def update(self, request, *args, **kwargs):
         material_request = self.get_object()
@@ -463,13 +474,11 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer_class()(material_request, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
 
-        def field_changed(field_name):
-            return field_name in request.data and serializer.validated_data[field_name] != getattr(
-                material_request, field_name
-            )
+        serializer.save()
+        material_request.refresh_from_db()
 
         if request.user == material_request.requester:
-            if field_changed("irb_attachment"):
+            if field_changed("irb_attachment", original_material_request, material_request):
                 add_attachment_to_material_request(
                     material_request,
                     serializer.validated_data["irb_attachment"],
@@ -477,7 +486,9 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
                     request.user,
                 )
 
-            if field_changed("requester_signed_mta_attachment"):
+            if field_changed(
+                "requester_signed_mta_attachment", original_material_request, material_request
+            ):
                 add_attachment_to_material_request(
                     material_request,
                     serializer.validated_data["requester_signed_mta_attachment"],
@@ -485,7 +496,9 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
                     request.user,
                 )
         else:
-            if field_changed("executed_mta_attachment"):
+            if field_changed(
+                "executed_mta_attachment", original_material_request, material_request
+            ):
                 add_attachment_to_material_request(
                     material_request,
                     serializer.validated_data["executed_mta_attachment"],
@@ -510,11 +523,8 @@ class MaterialRequestViewSet(viewsets.ModelViewSet):
                             assigned_to=material_request.assigned_to,
                         ).save()
 
-        self.create_notifications(request, original_material_request, serializer)
-        self.create_events(request, original_material_request, serializer)
-
-        serializer.save()
-        material_request.refresh_from_db()
+        self.create_notifications(request, original_material_request, material_request)
+        self.create_events(request, original_material_request, material_request)
 
         response_data = model_to_dict(material_request)
         response_data = MaterialRequestDetailSerializer(material_request).data


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/resources-portal/issues/635

## Purpose/Implementation Notes

We were sending notifications to the previous `assigned_to` instead of the updated `assigned_to`. While trying to fix it I realized that cleaning up the code and the order it does things would both fix the issue and make things easier to understand. Now we make a deep copy of the old object, update the object, and then compare the two. Nice and straight forward.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added a test to check that the new user is actually who gets put on the notification.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
