### PR TITLE
use updated api format for email invitations

### DIFF
--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -144,7 +144,7 @@ export default () => {
   const removeGrant = (teamId, grantId) =>
     api.teams.grants.remove(teamId, grantId, token)
 
-  const sendEmailInvite = (email) => api.invite(email, token)
+  const sendEmailInvite = (email) => api.invitations.create(email, token)
 
   const save = async () => {
     const teamRequest = team.id


### PR DESCRIPTION
## Issue Number

#630 

## Purpose/Implementation Notes

Fixes the call to the api which was previously `api.invite` to now match the crud format `api.invitations.create`

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
