### PR TITLE
Fix invitation emails

### DIFF
--- a/api/resources_portal/views/email_invitation.py
+++ b/api/resources_portal/views/email_invitation.py
@@ -43,14 +43,8 @@ def email_invitation_view(request):
     invitation_link = f"https://{settings.AWS_SES_DOMAIN}"
     terms_of_use_link = f"https://{settings.AWS_SES_DOMAIN}/terms-of-use"
 
-    # Format in image URLs.
-    alexs_logo_url = "https://{settings.AWS_SES_DOMAIN}/alexs-logo.png"
-    ccrr_logo_url = "https://{settings.AWS_SES_DOMAIN}/ccrr-logo.png"
-    formatted_html = EMAIL_HTML_BODY.replace("REPLACE_ALEXS_LOGO", alexs_logo_url)
-    formatted_html = formatted_html.replace("REPLACE_CCRR_LOGO", ccrr_logo_url)
-
     formatted_html = (
-        formatted_html.replace("REPLACE_MAIN_TEXT", body)
+        EMAIL_HTML_BODY.replace("REPLACE_MAIN_TEXT", body)
         .replace("REPLACE_CTA_LINK", invitation_link)
         .replace("REPLACE_TERMS_LINK", terms_of_use_link)
         .replace("REPLACE_ALEXS_LOGO", ALEXS_LOGO_URL)


### PR DESCRIPTION
## Issue Number

#668 

## Purpose/Implementation Notes

I got an invitation :tada:  It didn't have the images :sob: This should fix that up, it looks like it got change halfway, but some old code didn't get cleaned up and that caused the `REPLACE_` tags to get replaced with bad URLs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
