### PR TITLE
Let browser open filepicker

### DIFF
--- a/client/src/components/DropZone.js
+++ b/client/src/components/DropZone.js
@@ -27,7 +27,7 @@ export default ({ fileTypes = [], multiple = true, onDrop }) => {
         >
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <input {...getInputProps()} />
-          <Button label="Select Files" onClick={open} primary />
+          <Button label="Select Files" primary />
           <Text color="text-weak" margin={{ top: 'small', bottom: 'medium' }}>
             or drag and drop files
           </Text>

--- a/client/src/components/DropZone.js
+++ b/client/src/components/DropZone.js
@@ -11,7 +11,7 @@ export default ({ fileTypes = [], multiple = true, onDrop }) => {
       onDrop={onDrop}
       maxSize={1000000000}
     >
-      {({ getRootProps, getInputProps, open }) => (
+      {({ getRootProps, getInputProps }) => (
         <Box
           {...getRootProps()} // eslint-disable-line react/jsx-props-no-spreading
           width="full"


### PR DESCRIPTION
## Issue Number

#593 

## Purpose/Implementation Notes

This removed the client from manually triggering the file picker. This will need to be tested more but it seems that the behavior is the same on FF/Chrome on osx but should prevent linux based machines from opening 2 filepickers and ignoring the input from the first one.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
