### PR TITLE
remove list resource privately button

### DIFF
--- a/client/src/components/resources/ImportResource.js
+++ b/client/src/components/resources/ImportResource.js
@@ -60,6 +60,7 @@ export default () => {
                 disabled={fetched}
                 onClick={async () => {
                   if (await fetchImport()) {
+                    // todo:: validate here before showing preview view
                     setStep(1)
                   } else {
                     addAlert('An error occurred while importing', 'error')
@@ -124,7 +125,6 @@ export default () => {
             gap="large"
             margin={{ vertical: 'large' }}
           >
-            <Button label="List Privately" />
             <Button
               primary
               onClick={async () => {


### PR DESCRIPTION
## Issue Number

#602 

## Purpose/Implementation Notes

Removes the button to list privately - it wasnt implemented and feature has been punted.

Adds reminder to add auto-validation after fetching import. Just where to put that code not to keep track of the issue.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a 
