### PR TITLE
remove imported model organism fields

### DIFF
--- a/client/src/components/resources/configs/modelOrganism.js
+++ b/client/src/components/resources/configs/modelOrganism.js
@@ -35,6 +35,7 @@ export const importForm = (importSource) => {
     return [
       {
         basic_information: [
+          'url',
           'title',
           'organisms',
           'description',
@@ -46,6 +47,7 @@ export const importForm = (importSource) => {
   return [
     {
       basic_information: [
+        'url',
         'title',
         'organisms',
         'description',

--- a/client/src/components/resources/configs/modelOrganism.js
+++ b/client/src/components/resources/configs/modelOrganism.js
@@ -31,17 +31,13 @@ export const listForm = [
 ]
 
 export const importForm = (importSource) => {
-  if (importSource === 'ZIRC') {
+  if (['ZIRC', 'JACKSON_LABS'].includes(importSource)) {
     return [
       {
         basic_information: [
           'title',
           'organisms',
           'description',
-          'genetic_background',
-          'zygosity',
-          'number_of_available_models',
-          'construct_details',
           'additional_info'
         ]
       }

--- a/client/src/schemas/material.js
+++ b/client/src/schemas/material.js
@@ -60,11 +60,12 @@ const importedCategories = {
   }),
   MODEL_ORGANISM: object({
     description: string().required(),
-    genetic_background: string().required(),
-    zygosity: string().required(),
-    number_of_available_models: string().required(),
-    construct_details: string().required(),
-    additional_info: string()
+    additional_info: string(),
+    // the following are not asked for currently for imports
+    genetic_background: string(),
+    zygosity: string(),
+    number_of_available_models: string(),
+    construct_details: string()
   }),
   // this currently can't be imported
   // when it can remove keys which have no inputs


### PR DESCRIPTION
## Issue Number

#599 #600 

## Purpose/Implementation Notes

Removes the form fields and schema requirements for:
```
          'genetic_background',
          'zygosity',
          'number_of_available_models',
          'construct_details',
```

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
