### PR TITLE
Fix plain text email and recipients for ORGANIZATION_BECAME_OWNER notification

### DIFF
--- a/api/resources_portal/models/email_notifications_config.py
+++ b/api/resources_portal/models/email_notifications_config.py
@@ -510,7 +510,8 @@ EMAIL_NOTIFICATIONS = {
         "CTA": "Manage Team",
         "CTA_link_field": "organization",
         "plain_text_email": (
-            "{other_name} was added to {organization_name}."
+            "{other_name} has made you the owner of {organization_name}."
+            "\nYou can now add new team members and remove members and resources."
             "\n\nManage team. ({organization_url})."
         ),
         "required_associations": ["associated_user", "organization",],

--- a/api/resources_portal/views/organization.py
+++ b/api/resources_portal/views/organization.py
@@ -124,7 +124,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             organization.assign_owner_perms(new_owner)
 
             send_notifications(
-                "ORGANIZATION_BECAME_OWNER", request.user, new_owner, organization,
+                "ORGANIZATION_BECAME_OWNER", new_owner, request.user, organization,
             )
             send_notifications(
                 "ORGANIZATION_NEW_OWNER", request.user, new_owner, organization,


### PR DESCRIPTION
## Issue Number

#622 

## Purpose/Implementation Notes

This notification had the users backwards. It also had the wrong text for the plain text email.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I got a couple notifications to output their plaintext during an ownership transfer test:

ORGANIZATION_BECAME_OWNER: 
```
Barbara Burton,
Aaron Walters has made you the owner of test_organization.
You can now add new team members and remove members and resources.

Manage team. (https://None/account/teams/1).

The CCRR Team
-----
You are receiving this email because you subscribed to receive notifications from CCRR portal.
Manage Notifications (https://None/account/notifications/settings)
Alex's Lemonade Stand Foundation
111 Presidential Blvd, Suite 203, Bala Cynwyd,  PA 19004

2020-12-03 20:51:39,370 MainProcess resources_portal.models.notification INFO: Sending an email notification to maria86@anderson.com.
```

ORGANIZATION_NEW_OWNER:
```
Randy Fleming,
Barbara Burton is now the owner of test_organization.

View team. (https://None/account/teams/1).

The CCRR Team
-----
You are receiving this email because you subscribed to receive notifications from CCRR portal.
Manage Notifications (https://None/account/notifications/settings)
Alex's Lemonade Stand Foundation
111 Presidential Blvd, Suite 203, Bala Cynwyd,  PA 19004
```

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
