### PR TITLE
deploy client without CLIENT_HOST

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,16 +1,30 @@
 const path = require('path')
 
 module.exports = () => {
+  const isProduction = process.env.VERCEL_GIT_COMMIT_REF === 'master'
+
+  const productionEnv = {
+    API_VERSION: process.env.API_VERSION,
+    API_HOST: process.env.API_HOST,
+    ORCID_CLIENT_ID: process.env.ORCID_CLIENT_ID,
+    ORCID_URL: process.env.ORCID_URL,
+    SENTRY_DSN: process.env.SENTRY_DSN,
+    SENTRY_ENV: process.env.SENTRY_ENV
+  }
+
+  const stageEnv = {
+    API_VERSION: process.env.STAGE_API_VERSION,
+    API_HOST: process.env.STAGE_API_HOST,
+    ORCID_CLIENT_ID: process.env.STAGE_ORCID_CLIENT_ID,
+    ORCID_URL: process.env.STAGE_ORCID_URL,
+    SENTRY_DSN: process.env.STAGE_SENTRY_DSN,
+    SENTRY_ENV: process.env.STAGE_SENTRY_ENV
+  }
+
+  const env = isProduction ? productionEnv : stageEnv
+
   return {
-    env: {
-      API_VERSION: 'v1',
-      API_HOST: process.env.API_HOST,
-      CLIENT_HOST: process.env.CLIENT_HOST,
-      ORCID_CLIENT_ID: process.env.ORCID_CLIENT_ID,
-      ORCID_URL: process.env.ORCID_URL,
-      SENTRY_DSN: process.env.SENTRY_DSN,
-      SENTRY_ENV: process.env.SENTRY_ENV
-    },
+    env,
     experimental: {
       productionBrowserSourceMaps: true
     },

--- a/client/src/components/CreateUser.js
+++ b/client/src/components/CreateUser.js
@@ -1,3 +1,6 @@
+import React from 'react'
+import { Box, Heading } from 'grommet'
+import { useRouter } from 'next/router'
 import {
   CreateAccountStep,
   EnterEmailStep,
@@ -5,16 +8,14 @@ import {
   VerifyGrantStep
 } from 'components/CreateAccount'
 import { ProgressBar } from 'components/ProgressBar'
-import { Box, Heading } from 'grommet'
 import { useCreateUser } from 'hooks/useCreateUser'
-import { useRouter } from 'next/router'
-import React from 'react'
+import getRedirectQueryParam from 'helpers/getRedirectQueryParam'
 
-export default ({ ORCID, originUrl, code, stepName }) => {
+export default ({ ORCID, clientPath, code, stepName }) => {
   const router = useRouter()
   const { newUser, steps, currentStep, setCurrentStep } = useCreateUser(
     code,
-    originUrl
+    getRedirectQueryParam(clientPath)
   )
 
   React.useEffect(() => {

--- a/client/src/helpers/getOrcidUrl.js
+++ b/client/src/helpers/getOrcidUrl.js
@@ -1,5 +1,7 @@
 // returns link to orcid for oauth
+import getRedirectQueryParam from 'helpers/getRedirectQueryParam'
+
 export default (redirectPath = '/account') => {
-  const redirectUri = decodeURI(`${process.env.CLIENT_HOST}${redirectPath}`)
+  const redirectUri = getRedirectQueryParam(redirectPath)
   return `${process.env.ORCID_URL}oauth/authorize?client_id=${process.env.ORCID_CLIENT_ID}&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}`
 }

--- a/client/src/helpers/getRedirectQueryParam.js
+++ b/client/src/helpers/getRedirectQueryParam.js
@@ -1,0 +1,4 @@
+// this code can only be run on the client
+export default (path = '') => {
+  return decodeURI(`${window.location.origin}${path}`)
+}

--- a/client/src/pages/account/index.js
+++ b/client/src/pages/account/index.js
@@ -2,15 +2,15 @@ import React from 'react'
 import { Loader } from 'components/Loader'
 import { EnterEmailModal } from 'components/modals/EnterEmailModal'
 import { useSignIn } from 'hooks/useSignIn'
-
+import getRedirectQueryParam from 'helpers/getRedirectQueryParam'
 // This page should only:
 // 1) finish sign up by asking for email
 // 2) let the hook redirect the user to where they left off
 
-export const Account = ({ code, originUrl }) => {
+export const Account = ({ code, clientPath }) => {
   const { needsEmail, setEmail, setNeedsEmail, setError } = useSignIn(
     code,
-    originUrl
+    getRedirectQueryParam(clientPath)
   )
 
   if (needsEmail) {
@@ -29,12 +29,9 @@ export const Account = ({ code, originUrl }) => {
 }
 
 Account.getInitialProps = async ({ req, query }) => {
-  // Revisit how to present errors thrown from this function
-  const originUrl = decodeURI(`${process.env.CLIENT_HOST}${req ? req.url : ''}`)
-
   return {
     code: query.code,
-    originUrl
+    clientPath: req ? req.url : ''
   }
 }
 

--- a/client/src/pages/create-account/index.js
+++ b/client/src/pages/create-account/index.js
@@ -8,14 +8,14 @@ const CreateUser = dynamic(() => import('components/CreateUser'), {
   ssr: false
 })
 
-const CreateAccount = ({ ORCID, defaultUser, code, originUrl, stepName }) => {
+const CreateAccount = ({ ORCID, defaultUser, code, clientPath, stepName }) => {
   return (
     <CreateUserContextProvider defaultUser={defaultUser}>
       <Box fill align="center" justify="center">
         <Box width="large" margin={{ bottom: 'xlarge' }}>
           <CreateUser
             ORCID={ORCID}
-            originUrl={originUrl}
+            clientPath={clientPath}
             code={code}
             stepName={stepName}
           />
@@ -36,7 +36,7 @@ CreateAccount.getInitialProps = async ({ req, query }) => {
     ORCID: query.ORCID,
     defaultUser,
     code: query.code,
-    originUrl: decodeURI(`${process.env.CLIENT_HOST}${req.url}`),
+    clientPath: req ? req.url : '',
     stepName: query.stepName
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,13 +42,12 @@ services:
       - '${STORYBOOK_PORT}:${STORYBOOK_PORT}'
       - '${CLIENT_PORT}:${CLIENT_PORT}'
     environment:
-      API_VERSION: '${API_VERSION}'
-      API_HOST: 'http://localhost:${API_PORT}'
-      CLIENT_HOST: 'http://localhost:${CLIENT_PORT}'
-      ORCID_CLIENT_ID: '${ORCID_CLIENT_ID}'
-      ORCID_URL: '${ORCID_URL}'
-      SENTRY_DSN: '${SENTRY_DSN}'
-      SENTRY_ENV: '${SENTRY_ENV}'
+      STAGE_API_VERSION: '${API_VERSION}'
+      STAGE_API_HOST: 'http://localhost:${API_PORT}'
+      STAGE_ORCID_CLIENT_ID: '${ORCID_CLIENT_ID}'
+      STAGE_ORCID_URL: '${ORCID_URL}'
+      STAGE_SENTRY_DSN: '${SENTRY_DSN}'
+      STAGE_SENTRY_ENV: '${SENTRY_ENV}'
 
     command: >
       bash -c 'cd /home/user/code &&


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes


Since both stage and production are considered "production deploys"

This PR does the following:
* breaks up the env vars into `ENV_NAME` and `STAGE_ENV_NAME`
* production is determined from a master branch based deploy 
* preview and non-master deploys use `STAGE_ENV_NAME`
* moves the orcid redirect logic to the client so it doesnt require an env var

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Locally can create account and login 

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
