### PR TITLE
match what api expects OTHER_PAYMENT_METHODS

### DIFF
--- a/client/src/helpers/getPaymentOptions.js
+++ b/client/src/helpers/getPaymentOptions.js
@@ -10,7 +10,7 @@ export default (request) => {
     } = request.material.shipping_requirement
     if (shippingCode) paymentOptions.push('SHIPPING_CODE')
     if (reimbursement) paymentOptions.push('REIMBURSEMENT')
-    if (other) paymentOptions.push('OTHER_PAYMENT_METHOD')
+    if (other) paymentOptions.push('OTHER_PAYMENT_METHODS')
   }
   return paymentOptions.map((value) => ({ value, label: getReadable(value) }))
 }

--- a/client/src/helpers/readableNames.js
+++ b/client/src/helpers/readableNames.js
@@ -18,7 +18,7 @@ export const readableNames = {
   MODEL_ORGANISM: 'Model Organism',
   OPEN: 'Open',
   OTHER: 'Other',
-  OTHER_PAYMENT_METHOD: 'Other Payment Method',
+  OTHER_PAYMENT_METHODS: 'Other Payment Methods',
   PDX: 'PDX Model',
   PLASMID: 'Plasmid',
   PROTOCOL: 'Protocol',


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

This wasn't working because the API has the key as plural. This should fix that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

updated a material request with the following OTHER_PAYMENT_METHODS as payment_method

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

n/a
