### PR TITLE
610 show specify requirements when empty

### DIFF
--- a/client/src/components/resources/RequestRequirementsForm.js
+++ b/client/src/components/resources/RequestRequirementsForm.js
@@ -43,7 +43,9 @@ export default () => {
     setAttribute(attribute, value === 'true')
   }
 
-  const [showExisting, setShowExisting] = React.useState(true)
+  const [showExisting, setShowExisting] = React.useState(
+    teamResources && teamResources.length > 0
+  )
   const handleSelect = (resource) => {
     setExistingRequirementsResource(resource)
   }

--- a/client/src/components/resources/RequestRequirementsForm.js
+++ b/client/src/components/resources/RequestRequirementsForm.js
@@ -43,9 +43,9 @@ export default () => {
     setAttribute(attribute, value === 'true')
   }
 
-  const [showExisting, setShowExisting] = React.useState(
-    teamResources && teamResources.length > 0
-  )
+  const hasExisting = teamResources && teamResources.length > 0
+  const iconColor = hasExisting ? 'brand' : 'black-tint-80'
+  const [showExisting, setShowExisting] = React.useState(hasExisting)
   const handleSelect = (resource) => {
     setExistingRequirementsResource(resource)
   }
@@ -101,7 +101,8 @@ export default () => {
         <Button
           plain
           bold
-          icon={<Icon name="Plus" size="16px" />}
+          disabled={!hasExisting}
+          icon={<Icon name="Plus" size="16px" color={iconColor} />}
           label={toggleButtonLabel}
           onClick={toggleExisting}
         />


### PR DESCRIPTION
## Issue Number

#610 

## Purpose/Implementation Notes

When selecting existing requirements for your new resource...
Show the full form when there are no resources to pick from
Disable the button to toggle the view when the user has no resources to pick from

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
