### PR TITLE
645 naming personal org My Resources was a bad idea

### DIFF
--- a/api/resources_portal/test/views/test_user.py
+++ b/api/resources_portal/test/views/test_user.py
@@ -71,7 +71,7 @@ class TestUserPostTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(user.personal_organization.name, "My Resources")
+        self.assertEqual(user.personal_organization.name, user.full_name)
 
     @patch("orcid.PublicAPI", side_effect=generate_mock_orcid_record_response)
     @patch("requests.post", side_effect=generate_mock_orcid_authorization_response)

--- a/api/resources_portal/views/user.py
+++ b/api/resources_portal/views/user.py
@@ -235,7 +235,7 @@ class UserViewSet(viewsets.ModelViewSet):
             return JsonResponse({"error": error}, status=500)
 
         org = Organization.objects.create(
-            owner=user, name="My Resources", is_personal_organization=True
+            owner=user, name=user.full_name, is_personal_organization=True
         )
         user.personal_organization = org
 

--- a/client/src/components/resources/RequesterManageRequestForm.js
+++ b/client/src/components/resources/RequesterManageRequestForm.js
@@ -48,8 +48,6 @@ export default ({ request: defaultRequest }) => {
     }
   } = request
 
-  const teamName = team.name === 'Your Resources' ? contactName : team.name
-
   const {
     needsIrb,
     needsMta,
@@ -316,7 +314,7 @@ export default ({ request: defaultRequest }) => {
         {state === 'AWAITING_MTA' && (
           <Box width="full" pad={{ bottom: 'large' }}>
             <Text textAlign="center" margin="none">
-              Waiting for {teamName} to review, sign, and upload the MTA.
+              Waiting for {team.name} to review, sign, and upload the MTA.
             </Text>
           </Box>
         )}
@@ -326,7 +324,7 @@ export default ({ request: defaultRequest }) => {
           <Box pad={{ bottom: 'large' }}>
             <Box margin={{ veritcal: 'medium' }}>
               <Text>
-                {teamName} is working to fulfill your request. Your resource
+                {team.name} is working to fulfill your request. Your resource
                 should be on the way soon.
               </Text>
               {request.payment_method === 'REIMBURSEMENT' && (
@@ -348,7 +346,7 @@ export default ({ request: defaultRequest }) => {
           <>
             <Box pad={{ bottom: 'large' }}>
               <Text textAlign="center">
-                {teamName} has marked your request as fulfilled. Please look at
+                {team.name} has marked your request as fulfilled. Please look at
                 the fulfillment note for details.
               </Text>
             </Box>
@@ -423,7 +421,7 @@ export default ({ request: defaultRequest }) => {
             Problem with received resources?{' '}
             <Button
               plain
-              label={`Let ${teamName} know`}
+              label={`Let ${team.name} know`}
               onClick={() => setShowReportModal(true)}
             />
           </Text>

--- a/client/src/helpers/renamePersonalOrg.js
+++ b/client/src/helpers/renamePersonalOrg.js
@@ -1,0 +1,13 @@
+export const renameOrg = (org, name = 'My Resources') => {
+  return { ...org, name }
+}
+
+export default (orgOrOrgs) => {
+  if (Array.isArray(orgOrOrgs)) {
+    return orgOrOrgs.map((org) => {
+      if (!org.is_personal_organization) return org
+      return renameOrg(org)
+    })
+  }
+  return renameOrg(orgOrOrgs)
+}

--- a/client/src/hooks/useResourceForm.js
+++ b/client/src/hooks/useResourceForm.js
@@ -9,6 +9,7 @@ import {
 import configs, { formDefaults } from 'components/resources/configs'
 import schema from 'schemas/material'
 import { getToken, getReadable } from 'helpers/readableNames'
+import renamePersonalOrg from 'helpers/renamePersonalOrg'
 import { ResourceContext } from 'contexts/ResourceContext'
 import { useAlertsQueue } from 'hooks/useAlertsQueue'
 import api from 'api'
@@ -51,7 +52,7 @@ export default () => {
     return undefined
   }
 
-  const organizationOptions = [...(user.organizations || [])]
+  const organizationOptions = [...renamePersonalOrg(user.organizations || [])]
 
   const grant = resource
     ? grantOptions.find((g) => g.id === resource.grant_id) || {}


### PR DESCRIPTION
## Issue Number

#645 

## Purpose/Implementation Notes

So it was probably a bad idea to rename the personal org's `My Resources`. It seems more prudent to rewrite the form drop down when listing/importing a resource (one location) than modifying it whenever we send out a notification or a when the requester fields the requirements/contacts/waits for action from the org (this happens in like a million places).

 - sets the default name of the personal org to the user.full_name
 - This adds a helper for taking a single org or list of orgs and renames anything where is_personal_organization is true to 'My Resources' (this only happens when listing the resources.
 - implements the helper in the list/add drop down organization picker component
 - removes unneeded code which the above changes handle

We could probably add a migration for this change since the staging db will still look wonky. But all new personal organizations will be named after their owner. We could also one time change the db on staging.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested listing and managing a resource request from both sides of the process

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

n/a
