### PR TITLE
652 let team members leave team

### DIFF
--- a/client/src/components/TeamMembers.js
+++ b/client/src/components/TeamMembers.js
@@ -9,7 +9,15 @@ import { useAlertsQueue } from 'hooks/useAlertsQueue'
 
 export default () => {
   const { addAlert } = useAlertsQueue()
-  const { team, removeMember, transferOwnership, invites, save } = useTeamForm()
+  const {
+    user,
+    team,
+    removeMember,
+    leaveTeam,
+    transferOwnership,
+    invites,
+    save
+  } = useTeamForm()
   const [showTeamModal, setShowTeamModal] = React.useState(false)
   const saveRef = React.useRef(false)
 
@@ -58,8 +66,12 @@ export default () => {
       <TeamMembersTable
         team={team}
         onDelete={(member) => {
-          removeMember(member)
-          saveRef.current = 'Member Removed'
+          if (user.id === member.id) {
+            leaveTeam(member)
+          } else {
+            removeMember(member)
+            saveRef.current = 'Member Removed'
+          }
         }}
         onTransferOwner={(newOwner) => {
           transferOwnership(newOwner)

--- a/client/src/components/TeamMembersLeaveTeam.js
+++ b/client/src/components/TeamMembersLeaveTeam.js
@@ -12,7 +12,7 @@ export default ({ showing, setShowing, team, onLeaveTeam }) => {
   return (
     <Modal
       critical
-      title="Transfer Owner"
+      title="Leave Team"
       showing={showing}
       setShowing={setShowing}
     >

--- a/client/src/components/TeamMembersLeaveTeam.js
+++ b/client/src/components/TeamMembersLeaveTeam.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Box, Button, Paragraph, Text } from 'grommet'
+import { Modal } from 'components/Modal'
+import { InfoCard } from 'components/InfoCard'
+
+export default ({ showing, setShowing, team, onLeaveTeam }) => {
+  const leaveTeam = () => {
+    setShowing(false)
+    onLeaveTeam(true)
+  }
+
+  return (
+    <Modal
+      critical
+      title="Transfer Owner"
+      showing={showing}
+      setShowing={setShowing}
+    >
+      <Box width="large">
+        <InfoCard elevation="none" type="Warning" iconColor="error">
+          <Paragraph>
+            Are you sure you want to leave{' '}
+            <Text weight="bold">{team.name}</Text>?
+          </Paragraph>
+          <Paragraph>
+            <Text weight="bold">You cannot revert this change.</Text>{' '}
+          </Paragraph>
+        </InfoCard>
+        <Box direction="row" justify="end" gap="medium">
+          <Button label="Cancel" onClick={() => setShowing(false)} />
+          <Button primary label="Yes" onClick={leaveTeam} />
+        </Box>
+      </Box>
+    </Modal>
+  )
+}

--- a/client/src/components/TeamMembersTable.js
+++ b/client/src/components/TeamMembersTable.js
@@ -4,10 +4,12 @@ import { useUser } from 'hooks/useUser'
 import Icon from 'components/Icon'
 import TableButton from 'components/TableButton'
 import TeamMembersChangeOwner from 'components/TeamMembersChangeOwner'
+import TeamMembersLeaveTeam from 'components/TeamMembersLeaveTeam'
 
 export default ({ team, onDelete, onTransferOwner }) => {
   const { user } = useUser()
   const [showTransferOwner, setShowTransferOwner] = React.useState(false)
+  const [showLeaveTeam, setShowLeaveTeam] = React.useState(false)
   const canTransfer = team.members.length > 1
   const userIsOwner = !team.owner || team.owner.id === user.id
   const memberIsUser = (member) => {
@@ -72,9 +74,28 @@ export default ({ team, onDelete, onTransferOwner }) => {
               </>
             )}
             {memberIsOwner(member) && !userIsOwner && (
-              <Text italic color="black-tint-60">
+              <Text italic color="black-tint-60" margin={{ right: 'medium' }}>
                 (Owner)
               </Text>
+            )}
+            {memberIsUser(member) && !userIsOwner && (
+              <>
+                <TableButton
+                  plain
+                  icon={<Icon name="LeaveTeam" color="error" size="small" />}
+                  label="Leave Team"
+                  color="error"
+                  size="small"
+                  margin={{ right: 'medium' }}
+                  onClick={() => setShowLeaveTeam(true)}
+                />
+                <TeamMembersLeaveTeam
+                  showing={showLeaveTeam}
+                  setShowing={setShowLeaveTeam}
+                  onLeaveTeam={() => onDelete(member)}
+                  team={team}
+                />
+              </>
             )}
           </Box>
         </Box>

--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -1,10 +1,12 @@
 import React from 'react'
+import { useRouter } from 'next/router'
 import { useUser } from 'hooks/useUser'
 import { useAlertsQueue } from 'hooks/useAlertsQueue'
 import { TeamContext } from 'contexts/TeamContext'
 import api from 'api'
 
 export default () => {
+  const router = useRouter()
   const { addAlert } = useAlertsQueue()
   const { user, token, refreshUser } = useUser()
   const {
@@ -167,6 +169,22 @@ export default () => {
     return true
   }
 
+  const leaveTeam = async (member) => {
+    if (member.id === team.owner.id) {
+      addAlert('Owners must transfer their team to a new owner.', 'error')
+      return false
+    }
+    const { isOk } = await api.teams.members.remove(team.id, member.id, token)
+    if (isOk) {
+      addAlert('You have left the team successfully.', 'success')
+      await refreshUser()
+      router.push('/account/teams')
+      return true
+    }
+    addAlert('An error occurred when saving please try again later', 'error')
+    return false
+  }
+
   return {
     user,
     team,
@@ -186,6 +204,7 @@ export default () => {
     teamFetched: !!team.id,
     addGrant,
     removeGrant,
-    transferOwnership
+    transferOwnership,
+    leaveTeam
   }
 }


### PR DESCRIPTION
## Issue Number

#652 

## Purpose/Implementation Notes

We will probably need to add some logic to the api that checks if the user is a point person for any requests and automatically reassigns those to the owner.

This implements the button on the side of the team members table for letting people leave a team.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

added myself to a team and left the team

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots


![Screen Shot 2021-01-12 at 11 18 41 AM](https://user-images.githubusercontent.com/1075609/104341966-5a4b2a80-54c8-11eb-8d32-dce75e426935.png)

![Screen Shot 2021-01-12 at 11 19 16 AM](https://user-images.githubusercontent.com/1075609/104341902-4bfd0e80-54c8-11eb-8bcc-959bd8c29384.png)
