### PR TITLE
628 only show add members component when owner is viewing team

### DIFF
--- a/client/src/components/TeamMembers.js
+++ b/client/src/components/TeamMembers.js
@@ -18,8 +18,10 @@ export default () => {
     invites,
     save
   } = useTeamForm()
+
   const [showTeamModal, setShowTeamModal] = React.useState(false)
   const saveRef = React.useRef(false)
+  const isOwner = user.id === team.owner.id
 
   React.useEffect(() => {
     const saveTeam = async (message) => {
@@ -40,28 +42,30 @@ export default () => {
           You have no members.
         </Text>
       )}
-      <Box direction="row" justify="end">
-        <Button label="Add Members" onClick={() => setShowTeamModal(true)} />
-        <Modal
-          showing={showTeamModal}
-          setShowing={setShowTeamModal}
-          title="Add Members"
-        >
-          <Box width="large">
-            <TeamAddMembers showActions={false} />
-            <Box direction="row" justify="end">
-              <Button
-                label="Done"
-                onClick={async () => {
-                  setShowTeamModal(false)
-                  saveRef.current =
-                    invites.length > 0 ? 'Invites Sent' : 'Saved Changes'
-                }}
-              />
+      {isOwner && (
+        <Box direction="row" justify="end">
+          <Button label="Add Members" onClick={() => setShowTeamModal(true)} />
+          <Modal
+            showing={showTeamModal}
+            setShowing={setShowTeamModal}
+            title="Add Members"
+          >
+            <Box width="large">
+              <TeamAddMembers showActions={false} />
+              <Box direction="row" justify="end">
+                <Button
+                  label="Done"
+                  onClick={async () => {
+                    setShowTeamModal(false)
+                    saveRef.current =
+                      invites.length > 0 ? 'Invites Sent' : 'Saved Changes'
+                  }}
+                />
+              </Box>
             </Box>
-          </Box>
-        </Modal>
-      </Box>
+          </Modal>
+        </Box>
+      )}
       <HeaderRow label={`Members (${team.members.length})`} />
       <TeamMembersTable
         team={team}


### PR DESCRIPTION
## Issue Number

#628 

## Purpose/Implementation Notes

Checks if the user viewing the org/team is the owner. If they are then show the add members button.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

Member View:
![Screen Shot 2021-01-12 at 4 17 18 PM](https://user-images.githubusercontent.com/1075609/104375608-a5c5fe80-54f1-11eb-9cbf-f9d1b5ad8c3c.png)



Owner View:
![Screen Shot 2021-01-12 at 4 15 38 PM](https://user-images.githubusercontent.com/1075609/104375474-6ac3cb00-54f1-11eb-95d4-8377a1190f8f.png)

