### PR TITLE
634 update edit requirements

### DIFF
--- a/client/src/components/resources/RequestRequirementsForm.js
+++ b/client/src/components/resources/RequestRequirementsForm.js
@@ -263,15 +263,15 @@ export default () => {
             options={teamResourceOptions}
             name="existing-requirements"
           >
-            {({ resource, ...option }, { hover }) => (
+            {({ resource: existingResource, ...option }, { hover }) => (
               <RadioButton
                 key={option.label}
                 name={option.name}
                 hover={hover}
                 checked={existingRequirementsResource.id === option.value}
                 value={option.value}
-                label={<RequirementsLabel resource={resource} />}
-                onChange={() => handleSelect(resource)}
+                label={<RequirementsLabel resource={existingResource} />}
+                onChange={() => handleSelect(existingResource)}
               />
             )}
           </ExistingResourcesRadioButtonGroup>

--- a/client/src/components/resources/RequestRequirementsForm.js
+++ b/client/src/components/resources/RequestRequirementsForm.js
@@ -14,6 +14,7 @@ import DropZone from 'components/DropZone'
 import Icon from 'components/Icon'
 import useResourceForm from 'hooks/useResourceForm'
 import getResourceOptions from 'helpers/getResourceOptions'
+import getRequestRequirements from 'helpers/getRequestRequirements'
 import RequirementsLabel from 'components/resources/ResourceRequirementsRadioLabel'
 
 // this overrides the default styles for a RadioButtonGroup
@@ -28,6 +29,7 @@ const ExistingResourcesRadioButtonGroup = styled(RadioButtonGroup)`
 
 export default () => {
   const {
+    resource,
     setAttribute,
     getAttribute,
     setMtaAttachment,
@@ -35,7 +37,8 @@ export default () => {
     teamResources,
     grantOptions,
     existingRequirementsResource,
-    setExistingRequirementsResource
+    setExistingRequirementsResource,
+    isSaved
   } = useResourceForm()
   const onCheckChange = (attribute, { target: { checked } }) =>
     setAttribute(attribute, checked)
@@ -43,14 +46,16 @@ export default () => {
     setAttribute(attribute, value === 'true')
   }
 
+  const { hasRequirements } = getRequestRequirements(resource)
   const hasExisting = teamResources && teamResources.length > 0
   const iconColor = hasExisting ? 'brand' : 'black-tint-80'
-  const [showExisting, setShowExisting] = React.useState(hasExisting)
-  const handleSelect = (resource) => {
-    setExistingRequirementsResource(resource)
+  const [showExisting, setShowExisting] = React.useState(
+    existingRequirementsResource || (!hasRequirements && hasExisting)
+  )
+  const handleSelect = (requirementsResource) => {
+    setExistingRequirementsResource(requirementsResource)
   }
   const teamResourceOptions = getResourceOptions(teamResources, grantOptions)
-
   const toggleExisting = () => {
     if (showExisting) setExistingRequirementsResource('')
     setShowExisting(!showExisting)
@@ -75,12 +80,13 @@ export default () => {
     }
   }
 
-  const title = showExisting
-    ? 'Use same requirements as'
+  const formTitle = isSaved
+    ? 'Edit Request Requirements'
     : 'Specify New Requirements'
+  const title = showExisting ? 'Use Same Requirements As' : formTitle
   const toggleButtonLabel = showExisting
-    ? 'Specify new requirements'
-    : 'Use Existing Requirements'
+    ? formTitle
+    : 'Copy Requirements from Another Resource'
 
   return (
     <Box width="large" height={{ min: '500px' }}>

--- a/client/src/helpers/getRequestRequirements.js
+++ b/client/src/helpers/getRequestRequirements.js
@@ -20,8 +20,13 @@ export default (material) => {
     sharer_pays_shipping: sharerPaysShipping
   } = material.shipping_requirement || {}
 
+  // checks for mtaAttachment for accuracy before resource is saved
   const hasRequirements =
-    needsMta || needsIrb || needsAbstract || hasShippingRequirement
+    !!mtaAttachment ||
+    needsMta ||
+    needsIrb ||
+    needsAbstract ||
+    hasShippingRequirement
 
   return {
     hasRequirements,

--- a/client/src/hooks/useResourceForm.js
+++ b/client/src/hooks/useResourceForm.js
@@ -408,6 +408,7 @@ export default () => {
     clearResourceContext,
     teamResources,
     existingRequirementsResource,
-    setExistingRequirementsResource
+    setExistingRequirementsResource,
+    isSaved: !!resource.id
   }
 }


### PR DESCRIPTION
## Issue Number

#634 

## Purpose/Implementation Notes

So the main thing this PR does is correctly anticipate the version of the form to show when it is presented to a user:

For New resources show them the picker if they have something to pick from otherwise the regular form
For Editing Show Them the form by default unless it is unsaved and they picked a resource to copy requirements from

These are the form/picker titles
 - `Edit Request Requirements` (form when saved)
 - `Specify New Requirements` (form when unsaved)
 - `Copy Requirements from Another Resource` (picker button)

The only outlier is the title is not the same as the button for the picker
`Use Same Requirements As` ( picker title)

Also updated the `getRequestRequirements(resource)` helper to handle unsaved resources
Also added an `isSaved` export from useResourceForm to help with determining mode.


@dvenprasad I changed the copy from `Select Existing Resource` because the meaning is ambiguous when you are editing a saved (existing) resource.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

Tested new, edited, edit unsaved modes with new and existing requirements

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-01-12 at 5 12 06 PM](https://user-images.githubusercontent.com/1075609/104380911-bb3f2680-54f9-11eb-8724-f089aa1fb392.png)

