### PR TITLE
658 add hint for protocol_doi format

### DIFF
--- a/client/src/components/resources/ImportResource.js
+++ b/client/src/components/resources/ImportResource.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Button, FormField, TextInput, Paragraph } from 'grommet'
+import { Box, Button, FormField, Text, TextInput, Paragraph } from 'grommet'
 import { useRouter } from 'next/router'
 import { InfoCard } from 'components/InfoCard'
 import ResourceImportSourceSelector from 'components/resources/ResourceImportSourceSelector'
@@ -38,6 +38,16 @@ export default () => {
     if (!getAttribute('imported')) setAttribute('imported', true)
   })
 
+  const importFieldInfo = {
+    protocol_doi: (
+      <Paragraph size="small" color="black-tint-40">
+        Please use the following format:{' '}
+        <Text size="small" weight="bold">
+          dx.doi.org/10.17504/protocols.io.bj64krgw
+        </Text>
+      </Paragraph>
+    )
+  }
   return (
     <Box align="center">
       {step === 0 && (
@@ -45,7 +55,11 @@ export default () => {
           <ResourceImportSourceSelector />
           {isSupported && (
             <>
-              <FormField fill label={getReadable(importAttribute)}>
+              <FormField
+                fill
+                label={getReadable(importAttribute)}
+                info={importFieldInfo[importAttribute]}
+              >
                 <TextInput
                   value={getAttribute(importAttribute) || ''}
                   onChange={({ target: { value } }) => {

--- a/client/src/components/resources/ImportResource.js
+++ b/client/src/components/resources/ImportResource.js
@@ -58,7 +58,7 @@ export default () => {
               <FormField
                 fill
                 label={getReadable(importAttribute)}
-                info={importFieldInfo[importAttribute]}
+                help={importFieldInfo[importAttribute]}
               >
                 <TextInput
                   value={getAttribute(importAttribute) || ''}


### PR DESCRIPTION
## Issue Number

#658 

## Purpose/Implementation Notes

Adds a small helper which shows the accepted format without the `http(s)://`

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-01-12 at 5 47 28 PM](https://user-images.githubusercontent.com/1075609/104383928-a44f0300-54fe-11eb-823b-e0dfe7597d3a.png)

