### PR TITLE
break up fulfilled and verified fulfilled states

### DIFF
--- a/client/src/components/resources/RequesterManageRequestForm.js
+++ b/client/src/components/resources/RequesterManageRequestForm.js
@@ -58,8 +58,12 @@ export default ({ request: defaultRequest }) => {
   const materialLink = `/resources/${request.material.id}`
 
   const state = getRequestState(request)
+  const fulfilledState =
+    state === 'IN_FULFILLMENT_ISSUE_REPORTED' ? 'IN_FULFILLMENT' : state
+  const indexState =
+    fulfilledState === 'VERIFIED_FULFILLED' ? 'FULFILLED' : fulfilledState
   const progressSteps = getRequestProgressStatuses(request)
-  const progressIndex = progressSteps.indexOf(state)
+  const progressIndex = progressSteps.indexOf(indexState)
 
   // Report Issues
   const [showReportModal, setShowReportModal] = React.useState(false)
@@ -195,9 +199,16 @@ export default ({ request: defaultRequest }) => {
             index={progressIndex}
           />
         </Box>
-        <Text size="large" serif margin={{ bottom: 'medium' }}>
-          {state === 'OPEN' ? 'Open Request' : getReadable(state)}
-        </Text>
+        <Box direction="row" align="center" gap="small">
+          <Text size="large" serif margin={{ bottom: 'medium' }}>
+            {state === 'OPEN' ? 'Open Request' : getReadable(state)}
+          </Text>
+          {state === 'VERIFIED_FULFILLED' && (
+            <Text margin={{ top: '-8px' }}>
+              <Icon name="Check" color="success" />
+            </Text>
+          )}
+        </Box>
         {state === 'OPEN' && (
           <Box pad={{ veritcal: 'large' }}>
             <HeaderRow label="Submitted Materials" />
@@ -342,12 +353,34 @@ export default ({ request: defaultRequest }) => {
             )}
           </Box>
         )}
-        {['FULFILLED', 'VERIFIED_FULFILLED'].includes(state) && (
+        {['FULFILLED'].includes(state) && (
           <>
             <Box pad={{ bottom: 'large' }}>
               <Text textAlign="center">
                 {team.name} has marked your request as fulfilled. Please look at
                 the fulfillment note for details.
+              </Text>
+            </Box>
+            <Box margin={{ vertical: 'medium' }}>
+              <HeaderRow label="Request Materials" />
+              <Text weight="bold">Fulfullment Note</Text>
+              {request.fulfillment_notes.map((note) => (
+                <Text key={note.id}>{note.text}</Text>
+              ))}
+              {request.fulfillment_notes.length === 0 && (
+                <Text color="black-tint-60" italic>
+                  There are no notes.
+                </Text>
+              )}
+            </Box>
+          </>
+        )}
+        {['VERIFIED_FULFILLED'].includes(state) && (
+          <>
+            <Box pad={{ bottom: 'large' }}>
+              <Text textAlign="center">
+                You have confirmed reciept of this resource. Please look at the
+                fulfillment note for details.
               </Text>
             </Box>
             <Box margin={{ vertical: 'medium' }}>

--- a/client/src/components/resources/SharerManageRequestForm.js
+++ b/client/src/components/resources/SharerManageRequestForm.js
@@ -170,9 +170,16 @@ export default ({ request: defaultRequest }) => {
             index={progressIndex}
           />
         </Box>
-        <Text size="large" serif margin={{ bottom: 'medium' }}>
-          {state === 'OPEN' ? 'Open Request' : getReadable(state)}
-        </Text>
+        <Box direction="row" align="center" gap="small">
+          <Text size="large" serif margin={{ bottom: 'medium' }}>
+            {state === 'OPEN' ? 'Open Request' : getReadable(state)}
+          </Text>
+          {state === 'VERIFIED_FULFILLED' && (
+            <Text margin={{ top: '-8px' }}>
+              <Icon name="Check" color="success" />
+            </Text>
+          )}
+        </Box>
         {state === 'OPEN' && (
           <Box pad={{ bottom: 'large' }}>
             <Text margin={{ left: 'large', bottom: 'medium' }}>
@@ -415,9 +422,16 @@ export default ({ request: defaultRequest }) => {
             </Modal>
           </Box>
         )}
-        {['FULFILLED', 'VERIFIED_FULFILLED'].includes(state) && (
+        {['FULFILLED'].includes(state) && (
           <Box direction="row" align="center" pad="medium">
             <Text>This request has been fulfilled.</Text>
+          </Box>
+        )}
+        {['VERIFIED_FULFILLED'].includes(state) && (
+          <Box direction="row" align="center" pad="medium">
+            <Text>
+              {requester.full_name} has confirmed the receipt of this resource.
+            </Text>
           </Box>
         )}
         {hasDocuments && state !== 'OPEN' && (


### PR DESCRIPTION
## Issue Number

#643 

## Purpose/Implementation Notes

Breaks up the two fulfilled states for both the requester and sharer views.
Also fixes an issue where the fulfilled progressbar was greyed out instead of brand blue

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested both locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-01-13 at 4 18 05 PM](https://user-images.githubusercontent.com/1075609/104511813-492f1600-55bb-11eb-90c3-1d343b1cc6d5.png)
![Screen Shot 2021-01-13 at 4 18 00 PM](https://user-images.githubusercontent.com/1075609/104511814-492f1600-55bb-11eb-9d89-1f155d50e326.png)

