### PR TITLE
638 - requests cards detail match structure

### DIFF
--- a/client/src/components/ManageRequestCard.js
+++ b/client/src/components/ManageRequestCard.js
@@ -1,7 +1,5 @@
 import React from 'react'
 import { Anchor, Box, Button, Text } from 'grommet'
-import styled from 'styled-components'
-import Link from 'next/link'
 import Icon from 'components/Icon'
 import { ResourceTypeOrganisms } from 'components/resources/ResourceCard'
 import { Pill } from 'components/Pill'
@@ -9,6 +7,7 @@ import AssignRequestSelect from 'components/AssignRequestSelect'
 import { useUser } from 'hooks/useUser'
 import getRequestStatus from 'helpers/getRequestStatus'
 import { getReadable } from 'helpers/readableNames'
+import ResourceLink from 'components/ResourceLink'
 
 const getRequestConfig = (request) => {
   const status = getRequestStatus(request)
@@ -80,9 +79,6 @@ const getRequestConfig = (request) => {
   return config
 }
 
-const BoldAnchor = styled(Anchor)`
-  font-weight: bold;
-`
 export default ({ request: defaultRequest }) => {
   const [request, setRequest] = React.useState(defaultRequest)
   const { isResourceRequester } = useUser()
@@ -98,7 +94,6 @@ export default ({ request: defaultRequest }) => {
     ? 'Waiting on Requester'
     : 'Requires Action'
   const fallbackDate = new Date(request.created_at).toDateString()
-  const resourceLink = `/resources/${request.material.id}`
 
   return (
     <Box elevation="medium" round="small" overflow="hidden">
@@ -123,9 +118,7 @@ export default ({ request: defaultRequest }) => {
       </Box>
       <Box direction="row" align="center" pad="medium" justify="between">
         <Box>
-          <Link href={resourceLink}>
-            <BoldAnchor href={resourceLink} label={request.material.title} />
-          </Link>
+          <ResourceLink resource={request.material} />
           <Anchor
             margin={{ vertical: 'medium' }}
             href={`mailto:${request.requester.email}`}

--- a/client/src/components/ResourceLink.js
+++ b/client/src/components/ResourceLink.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import Link from 'next/link'
+import { Anchor } from 'grommet'
+import styled from 'styled-components'
+
+const AnchorBold = styled(Anchor)`
+  font-weight: 600;
+`
+
+export default ({ resource }) => {
+  const href = `/resources/${resource.id}`
+  return (
+    <Link href={href}>
+      <AnchorBold weight="600" href={href} label={resource.title} />
+    </Link>
+  )
+}

--- a/client/src/components/resources/RequesterManageRequestForm.js
+++ b/client/src/components/resources/RequesterManageRequestForm.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from 'next/link'
 import {
   Anchor,
   Button,
@@ -34,6 +33,7 @@ import getRequestRequirements from 'helpers/getRequestRequirements'
 import getPaymentOptions from 'helpers/getPaymentOptions'
 import RequestMakeArrangements from 'components/RequestMakeArrangements'
 import { Modal } from 'components/Modal'
+import ResourceLink from 'components/ResourceLink'
 
 export default ({ request: defaultRequest }) => {
   const [request, setRequest] = React.useState(defaultRequest)
@@ -42,8 +42,7 @@ export default ({ request: defaultRequest }) => {
   const { addAlert } = useAlertsQueue()
   const {
     material: {
-      title: materialTitle,
-      contact_user: { email: contactEmail, full_name: contactName },
+      contact_user: { email: contactEmail },
       organization: team
     }
   } = request
@@ -54,8 +53,6 @@ export default ({ request: defaultRequest }) => {
     shippingRequirement: { needsPayment },
     mtaAttachment
   } = getRequestRequirements(request.material)
-
-  const materialLink = `/resources/${request.material.id}`
 
   const state = getRequestState(request)
   const fulfilledState =
@@ -171,10 +168,12 @@ export default ({ request: defaultRequest }) => {
         margin={{ bottom: 'large' }}
       >
         <Box gap="medium">
-          <Text>{contactName}</Text>
-          <Link href={materialLink}>
-            <Anchor href={materialLink} label={materialTitle} />
-          </Link>
+          <ResourceLink resource={request.material} />
+          <Anchor
+            margin={{ vertical: 'medium' }}
+            href={`mailto:${request.requester.email}`}
+            label={request.requester.full_name}
+          />
           <ResourceTypeOrganisms resource={request.material} />
         </Box>
         <Box>

--- a/client/src/components/resources/SharerManageRequestForm.js
+++ b/client/src/components/resources/SharerManageRequestForm.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from 'next/link'
 import { Anchor, Button, Box, Text, TextArea, FormField } from 'grommet'
 import api from 'api'
 import { getReadable } from 'helpers/readableNames'
@@ -29,6 +28,7 @@ import RequestAwaitingAdditionalDocuments from 'components/RequestAwaitingAdditi
 import RequestMakeArrangements from 'components/RequestMakeArrangements'
 import { List, ListItem, NumberMarker } from 'components/List'
 import PreviewIssue from 'components/PreviewIssue'
+import ResourceLink from 'components/ResourceLink'
 
 export default ({ request: defaultRequest }) => {
   const { addAlert } = useAlertsQueue()
@@ -39,13 +39,7 @@ export default ({ request: defaultRequest }) => {
   const [note, setNote] = React.useState('')
   const [executedMTA, setExecutedMTA] = React.useState(defaultExecutedMTA)
   const [showRejection, setShowRejection] = React.useState(false)
-  const {
-    material: {
-      title: materialTitle,
-      contact_user: { full_name: contactName }
-    },
-    requester
-  } = request
+  const { requester } = request
 
   const {
     needsIrb,
@@ -54,7 +48,6 @@ export default ({ request: defaultRequest }) => {
   } = getRequestRequirements(request.material)
 
   const hasDocuments = hasRequestDocuments(request.material)
-  const materialLink = `/resources/${request.material.id}`
 
   const state = getRequestState(request)
   // the states dont represent these special cases
@@ -149,10 +142,12 @@ export default ({ request: defaultRequest }) => {
         margin={{ bottom: 'large' }}
       >
         <Box gap="medium">
-          <Text>{contactName}</Text>
-          <Link href={materialLink}>
-            <Anchor href={materialLink} label={materialTitle} />
-          </Link>
+          <ResourceLink resource={request.material} />
+          <Anchor
+            margin={{ vertical: 'medium' }}
+            href={`mailto:${request.requester.email}`}
+            label={request.requester.full_name}
+          />
           <ResourceTypeOrganisms resource={request.material} />
         </Box>
         <Box>


### PR DESCRIPTION
## Issue Number

#638 

## Purpose/Implementation Notes

* Adds a new component `ResourceLink` which is just to help make sure the link to the resource is styled the same everywhere. 
* Orders the requests card and details page to be top - down resource link, requester, resource type


Note: the requester's detailpage also has their name up there at the top fwiw.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

`ManageRequestCard`
![Screen Shot 2021-01-14 at 12 16 28 PM](https://user-images.githubusercontent.com/1075609/104625081-55ba7980-5662-11eb-906b-2aea38470acd.png)


Requesters View Request Detail Page
![Screen Shot 2021-01-14 at 12 16 51 PM](https://user-images.githubusercontent.com/1075609/104625120-62d76880-5662-11eb-90cb-7cdd0616a75b.png)


Sharers View Request Detail Page
![Screen Shot 2021-01-14 at 12 17 45 PM](https://user-images.githubusercontent.com/1075609/104625228-84385480-5662-11eb-9688-7829ff8c2904.png)



