### PR TITLE
Fixes links for notification settings and terms of use in emails.

### DIFF
--- a/api/resources_portal/email_assets/notification_email_template.html
+++ b/api/resources_portal/email_assets/notification_email_template.html
@@ -1476,13 +1476,13 @@ body.outlook p {
                                   <table style="width:100%;">
                                     <tr>
                                       <td class="text-center">
-                                        <a href ="#">Terms of Use</a>
+                                        <a href="REPLACE_TERMS_LINK">Terms of Use</a>
                                       </td>
                                     </tr>
                                     <tr class="text-center">
                                       <td>
                                         You are receiving this email because you subscribed to receive notifications from CCRR portal.
-                                        <a href ="#">
+                                        <a href="REPLACE_NOTIFICATIONS_LINK">
                                           Manage Notifications
                                         </a>
                                       </td>

--- a/api/resources_portal/email_assets/weekly_email_template.html
+++ b/api/resources_portal/email_assets/weekly_email_template.html
@@ -1462,13 +1462,13 @@ body.outlook p {
                                   <table style="width:100%;">
                                     <tr>
                                       <td>
-                                        <a href ="#">Terms of Use</a>
+                                        <a href="REPLACE_TERMS_LINK">Terms of Use</a>
                                       </td>
                                     </tr>
                                     <tr>
                                       <td>
                                         You are receiving this email because you subscribed to receive notifications from CCRR portal.
-                                        <a href ="#">Manage Notifications</a>
+                                        <a href="REPLACE_NOTIFICATIONS_LINK">Manage Notifications</a>
                                       </td>
                                    </tr>
                                   </table>

--- a/api/resources_portal/emailer.py
+++ b/api/resources_portal/emailer.py
@@ -19,6 +19,7 @@ EMAIL_SOURCE = (
     else "Resources Portal Mail Robot"
 )
 NOTIFICATIONS_URL = f"https://{settings.AWS_SES_DOMAIN}/account/notifications/settings"
+TERMS_OF_USE_URL = f"https://{settings.AWS_SES_DOMAIN}/terms-of-use"
 ALEXS_LOGO_URL = f"https://{settings.AWS_SES_DOMAIN}/alexs-logo.png"
 CCRR_LOGO_URL = f"https://{settings.AWS_SES_DOMAIN}/ccrr-logo.png"
 # The blank line in this footer is intentional:

--- a/api/resources_portal/management/commands/send_weekly_digest_emails.py
+++ b/api/resources_portal/management/commands/send_weekly_digest_emails.py
@@ -10,7 +10,9 @@ from resources_portal.emailer import (
     ALEXS_LOGO_URL,
     CCRR_LOGO_URL,
     EMAIL_SOURCE,
+    NOTIFICATIONS_URL,
     PLAIN_TEXT_EMAIL_FOOTER,
+    TERMS_OF_USE_URL,
     send_mail,
 )
 from resources_portal.models import User
@@ -82,9 +84,11 @@ def send_user_weekly_digest(user):
         .replace("REPLACE_NOTIFICATION_LIST", html_body_list)
         .replace("REPLACE_ALEXS_LOGO", ALEXS_LOGO_URL)
         .replace("REPLACE_CCRR_LOGO", CCRR_LOGO_URL)
+        .replace("REPLACE_NOTIFICATIONS_LINK", NOTIFICATIONS_URL)
+        .replace("REPLACE_TERMS_LINK", TERMS_OF_USE_URL)
     )
 
-    subject = "CCRR: Weekly Notification Digest"
+    subject = "ALSF CCRR: Weekly Notification Digest"
 
     send_mail(EMAIL_SOURCE, [user.email], subject, plain_text, html_body)
 

--- a/api/resources_portal/models/notification.py
+++ b/api/resources_portal/models/notification.py
@@ -16,6 +16,7 @@ from resources_portal.emailer import (
     EMAIL_SOURCE,
     NOTIFICATIONS_URL,
     PLAIN_TEXT_EMAIL_FOOTER,
+    TERMS_OF_USE_URL,
     send_mail,
 )
 from resources_portal.models.email_notifications_config import EMAIL_NOTIFICATIONS
@@ -169,6 +170,8 @@ class Notification(SafeDeleteModel, ComputedFieldsModel):
             .replace("REPLACE_MAIN_TEXT", body)
             .replace("REPLACE_ALEXS_LOGO", ALEXS_LOGO_URL)
             .replace("REPLACE_CCRR_LOGO", CCRR_LOGO_URL)
+            .replace("REPLACE_NOTIFICATIONS_LINK", NOTIFICATIONS_URL)
+            .replace("REPLACE_TERMS_LINK", TERMS_OF_USE_URL)
         )
         formatted_cta_html = ""
         cta = ""

--- a/api/resources_portal/views/email_invitation.py
+++ b/api/resources_portal/views/email_invitation.py
@@ -36,7 +36,7 @@ def email_invitation_view(request):
         return Response({"message": "Must specify 'email' in JSON."}, status=400)
 
     body = (
-        f"{request.user.full_name} has invited you to create a CCRR account to help"
+        f"{request.user.full_name} has invited you to create an ALSF CCRR account to help"
         f" them manage sharing resources. Please let them know once you create an account"
         f" so they can add you to the relevant teams."
     )


### PR DESCRIPTION
## Issue Number

#651 
#579 

## Purpose/Implementation Notes

Changes `CCRR` to `ALSF CCRR` in weekly digest subject.

Inserts notifications settings and terms of use links in emails where they weren't.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests still work  (we test these emails)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
