### PR TITLE
Associate materials with all grants for an org on creation.

### DIFF
--- a/api/resources_portal/test/end_to_end/test_organization_with_two_users.py
+++ b/api/resources_portal/test/end_to_end/test_organization_with_two_users.py
@@ -23,7 +23,7 @@ class TestOrganizationWithTwoUsers(APITestCase):
     3. Prof creates organization Lab with grant id.
     4. Prof invites Postdoc to join Lab.
     5. Postdoc accepts invitation to join Lab.
-    6. Prof lists resource under Lab.
+    6. Postdoc lists a resource under Lab on the Prof's behalf
     7. Prof removes all notification settings.
 
     During the test, the following notifications (and no more) will be sent:


### PR DESCRIPTION
## Issue Number

#753 

## Purpose/Implementation Notes

I'm confused why this was working for the owner. Was that misreported? Was the frontend creating the association with a separate call to the material-grants route?

Either way, from now on whenever a material is created it is associated with all grants on the org it's listed under.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added checks to an end-to-end test flow.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
