### PR TITLE
713 add analytics

### DIFF
--- a/client/src/pages/_document.js
+++ b/client/src/pages/_document.js
@@ -1,24 +1,16 @@
 import Document, { Head, Main, NextScript } from 'next/document'
 import React from 'react'
-// Import styled components ServerStyleSheet
 import { ServerStyleSheet } from 'styled-components'
 
-// thanks to https://dev.to/aprietof/nextjs--styled-components-the-really-simple-guide----101c
 export default class MyDocument extends Document {
+  // set up styled components
   static getInitialProps({ renderPage }) {
-    // Step 1: Create an instance of ServerStyleSheet
     const sheet = new ServerStyleSheet()
-
-    // Step 2: Retrieve styles from components in the page
     const page = renderPage((App) => (props) =>
       // eslint-disable-next-line react/jsx-props-no-spreading
       sheet.collectStyles(<App {...props} />)
     )
-
-    // Step 3: Extract the styles as <style> tags
     const styleTags = sheet.getStyleElement()
-
-    // Step 4: Pass styleTags as a prop
     return { ...page, styleTags }
   }
 

--- a/client/src/pages/_document.js
+++ b/client/src/pages/_document.js
@@ -18,7 +18,26 @@ export default class MyDocument extends Document {
     return (
       <html lang="en-US">
         <Head>
-          {/* Step 5: Output the styles in the head  */}
+          {/* Google Analytics */}
+          <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-BYH3X5WS0V"
+          />
+          <script
+            async
+            dangerouslySetInnterHTML={{
+              __html:
+                "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);} gtag('js', new Date());gtag('config', 'G-BYH3X5WS0V');"
+            }}
+          />
+          {/* Hotjar */}
+          <script
+            async
+            dangerouslySetInnterHTML={{
+              __html:
+                "(function(h,o,t,j,a,r){h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};h._hjSettings={hjid:2241444,hjsv:6};a=o.getElementsByTagName('head')[0];r=o.createElement('script');r.async=1;r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;a.appendChild(r);})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');"
+            }}
+          />
           {this.props.styleTags}
         </Head>
         <body>


### PR DESCRIPTION
## Issue Number

#713

## Purpose/Implementation Notes

Adds google analyics and hotjar scripts to be fired when the document loads in the browser.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a needs to be deployed to the prod domain to see events in the dash but the scripts look to be firing correctly.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
