### PR TITLE
749 update required fields for imported cell lines and plasmids

### DIFF
--- a/client/src/components/resources/ResourceEditImportedForm.js
+++ b/client/src/components/resources/ResourceEditImportedForm.js
@@ -16,7 +16,8 @@ export default () => {
     contactUserOptions,
     attributeHasError,
     fetched,
-    importAttribute
+    importAttribute,
+    optionalAttributes = []
   } = useResourceForm()
 
   return (
@@ -43,6 +44,7 @@ export default () => {
               attribute={attribute}
               contactUserOptions={contactUserOptions}
               error={attributeHasError(attribute)}
+              optionalAttributes={optionalAttributes}
               disabled={disableImportAttribute(attribute, importAttribute)}
             />
           ))}

--- a/client/src/components/resources/configs/cellLine.js
+++ b/client/src/components/resources/configs/cellLine.js
@@ -70,7 +70,6 @@ export const importForm = () => [
       'organisms',
       'tissue',
       'disease',
-      'number_of_available_cell_lines',
       'age',
       'sex',
       'ethnicity',

--- a/client/src/schemas/material.js
+++ b/client/src/schemas/material.js
@@ -39,7 +39,7 @@ const importedCategories = {
   CELL_LINE: object({
     cell_line_name: string().required(),
     tissue: string().required(),
-    disease: string().required(),
+    disease: string(),
     age: string(),
     sex: string(),
     ethnicity: string(),

--- a/client/src/schemas/material.js
+++ b/client/src/schemas/material.js
@@ -53,7 +53,7 @@ const importedCategories = {
     purpose: string(),
     number_of_available_samples: string(),
     gene_insert_name: string().required(),
-    relevant_mutations: string().required(),
+    relevant_mutations: string(),
     additional_info: string()
   }),
   PROTOCOL: object({

--- a/client/src/schemas/material.js
+++ b/client/src/schemas/material.js
@@ -40,7 +40,6 @@ const importedCategories = {
     cell_line_name: string().required(),
     tissue: string().required(),
     disease: string().required(),
-    number_of_available_cell_lines: string(),
     age: string(),
     sex: string(),
     ethnicity: string(),


### PR DESCRIPTION
## Issue Number

#749 #751 

## Purpose/Implementation Notes

* extra fields for resource details are addressed in #768
* shows optional field labels based on import requirements
* Import Plasmid
  * removes requirement of relevant mutations from add gene imports
* Import Cell Line
  * removes number of available cell lines from form and validator
  * makes disease optional (the others in the issue were optional but not shown as such) 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots
Plasmid import:
![Screen Shot 2021-02-12 at 2 51 03 PM](https://user-images.githubusercontent.com/1075609/107815696-bb715280-6d41-11eb-94eb-3587047feee6.png)

Cell Line Import:
![Screen Shot 2021-02-12 at 2 56 45 PM](https://user-images.githubusercontent.com/1075609/107816582-f88a1480-6d42-11eb-9b47-b2dbab8803bc.png)

