### PR TITLE
515 sentry has too many dialogue boxes

### DIFF
--- a/client/src/pages/_app.js
+++ b/client/src/pages/_app.js
@@ -16,6 +16,10 @@ const LoginRequired = dynamic(() => import('components/LoginRequired'), {
   ssr: false
 })
 
+const Fallback = (sentry) => {
+  return <Error sentry={sentry} />
+}
+
 export default ({ Component, pageProps, router: { pathname } }) => {
   const isHome = pathname === '/'
   const isAccount = pathname.indexOf('/account') === 0
@@ -30,7 +34,7 @@ export default ({ Component, pageProps, router: { pathname } }) => {
   })
 
   return (
-    <Sentry.ErrorBoundary fallback={Error} showDialog>
+    <Sentry.ErrorBoundary fallback={Fallback} showDialog>
       <ResourcesPortalContextProvider>
         <Head>
           <link

--- a/client/src/pages/_error.js
+++ b/client/src/pages/_error.js
@@ -1,26 +1,50 @@
 import React from 'react'
-import { Box, Button, Text } from 'grommet'
+import { Box, Button, Grommet, Text } from 'grommet'
 import { useRouter } from 'next/router'
+import theme from 'theme'
 
-export const ErrorPage = ({ errorMessage, eventId }) => {
+const ErrorPage = ({ sentry = {} }) => {
   const router = useRouter()
+
+  const { eventId } = sentry
+
+  React.useEffect(() => {
+    const forceRefresh = (url) => {
+      window.location = url
+    }
+
+    router.events.on('routeChangeStart', forceRefresh)
+  }, [])
+
+  const goBack = () => {
+    router.back()
+  }
+
   return (
-    <Box direction="row" justify="center" fill>
-      <Box direction="row" justify="center" align="center">
-        <Box align="start" width="full">
-          <Text size="xlarge" margin={{ bottom: 'large' }}>
-            Uh oh, something happened.
-          </Text>
-          {errorMessage && <Text>{errorMessage}</Text>}
-          {eventId && (
-            <Text size="small" color="error" round="small">
-              Error ID: {eventId}
+    <Grommet theme={theme} full>
+      <Box justify="center" fill>
+        <Box direction="row">
+          <Box align="center" width="full">
+            <Text size="xlarge" margin={{ bottom: 'large' }}>
+              Uh oh, something happened.
             </Text>
-          )}
-          <Button primary label="Go Back" onClick={() => router.back()} />
+            <Text>
+              We have been notified and are taking a look at the issue.
+            </Text>
+            {eventId && (
+              <Box margin={{ vertical: 'medium' }}>
+                <Text size="small" color="error" round="small">
+                  Error ID: {eventId}
+                </Text>
+              </Box>
+            )}
+            <Box direction="row" justify="center" width="full">
+              <Button primary label="Go Back" onClick={goBack} />
+            </Box>
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </Grommet>
   )
 }
 


### PR DESCRIPTION
## Issue Number

#515 

## Purpose/Implementation Notes

Sentry kept opening new dialogue boxes most likely because it did not have the fallback set up correctly.
I think since the fallback page wasnt being rendered the errors kept accumulating in the error boundary.
This PR corrects that implementation and cleans up the fallback page/component.
Also when an error is encountered it navigates to to the previous page (presumably one without an error) and hard refreshes the page. We will need to test this in stage to see if it suits out needs but it seems to be good enough.

Tagging @dvenprasad for copy check.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested with deliberate errors

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-02-12 at 4 30 41 PM](https://user-images.githubusercontent.com/1075609/107824641-cdf28880-6d4f-11eb-8315-12f7805c4023.png)

