### PR TITLE
604 indicate calls to action are actioning their calls

### DIFF
--- a/client/src/components/Button.js
+++ b/client/src/components/Button.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Button } from 'grommet'
+import useWaitForAsync from 'hooks/useWaitForAsync'
+
+export default ({ onClick, ...props }) => {
+  const [waiting, asyncOnClick] = useWaitForAsync(onClick)
+  const disabled = waiting || props.disabled
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Button {...props} onClick={asyncOnClick} disabled={disabled} />
+  )
+}

--- a/client/src/components/CreateAccountDetailsForm.js
+++ b/client/src/components/CreateAccountDetailsForm.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { string } from 'yup'
-import { Box, Button, Text, FormField, TextInput } from 'grommet'
+import { Box, Text, FormField, TextInput } from 'grommet'
+import Button from 'components/Button'
 import { useCreateUser } from 'hooks/useCreateUser'
 import { getReadable } from 'helpers/readableNames'
 

--- a/client/src/components/RequestAwaitingAdditionalDocumentsForm.js
+++ b/client/src/components/RequestAwaitingAdditionalDocumentsForm.js
@@ -1,12 +1,6 @@
 import React from 'react'
-import {
-  Box,
-  Text,
-  Button,
-  FormField,
-  TextArea,
-  RadioButtonGroup
-} from 'grommet'
+import { Box, Text, FormField, TextArea, RadioButtonGroup } from 'grommet'
+import Button from 'components/Button'
 import getPaymentOptions from 'helpers/getPaymentOptions'
 import DropZone from 'components/DropZone'
 import Icon from 'components/Icon'
@@ -136,8 +130,8 @@ export default () => {
         <Button
           primary
           label="Submit"
-          onClick={() => {
-            submitAdditionalDocuments({
+          onClick={async () => {
+            await submitAdditionalDocuments({
               irbAttachment,
               requesterMtaAttachment,
               paymentMethod,

--- a/client/src/components/RequestAwaitingMtaForm.js
+++ b/client/src/components/RequestAwaitingMtaForm.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Button, Text } from 'grommet'
+import { Box, Text } from 'grommet'
+import Button from 'components/Button'
 import { HeaderRow } from 'components/HeaderRow'
 import Icon from 'components/Icon'
 import DropZone from 'components/DropZone'

--- a/client/src/components/RequestButton.js
+++ b/client/src/components/RequestButton.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button } from 'grommet'
+import Button from 'components/Button'
 import Link from 'next/link'
 import CreateAccountLoginButton from 'components/CreateAccountLoginButton'
 import { useUser } from 'hooks/useUser'

--- a/client/src/components/TeamForm.js
+++ b/client/src/components/TeamForm.js
@@ -1,13 +1,6 @@
 import React from 'react'
-import {
-  Box,
-  Button,
-  CheckBox,
-  FormField,
-  TextInput,
-  Text,
-  TextArea
-} from 'grommet'
+import { Box, CheckBox, FormField, TextInput, Text, TextArea } from 'grommet'
+import Button from 'components/Button'
 import Link from 'next/link'
 import { HeaderRow } from 'components/HeaderRow'
 import TeamAddMembers from 'components/TeamAddMembers'
@@ -97,7 +90,7 @@ export default ({ teamId }) => {
           label="Create Team"
           onClick={async () => {
             const saved = await save()
-            if (saved) router.push('/account/teams')
+            if (saved) await router.push(`/account/teams/${saved.id}`)
           }}
         />
       </Box>

--- a/client/src/components/resources/ListResourceForm.js
+++ b/client/src/components/resources/ListResourceForm.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Button, Heading, Paragraph, Text } from 'grommet'
+import { Box, Heading, Paragraph, Text } from 'grommet'
+import Button from 'components/Button'
 import ResourceTypeSelector from 'components/resources/ResourceTypeSelector'
 import { ProgressBar } from 'components/ProgressBar'
 import ResourceDetailsForm from 'components/resources/ResourceDetailsForm'

--- a/client/src/components/resources/RequestResourceForm.js
+++ b/client/src/components/resources/RequestResourceForm.js
@@ -2,13 +2,13 @@ import React from 'react'
 import {
   Anchor,
   Box,
-  Button,
   CheckBox,
   FormField,
   Text,
   TextArea,
   TextInput
 } from 'grommet'
+import Button from 'components/Button'
 import { useRouter } from 'next/router'
 import styled from 'styled-components'
 import { HeaderRow } from 'components/HeaderRow'
@@ -237,7 +237,7 @@ export default ({ resource }) => {
           onClick={async () => {
             const saved = await createResourceRequest()
             if (saved && saved.id) {
-              router.push(`/account/requests/${saved.id}`)
+              await router.push(`/account/requests/${saved.id}`)
             }
           }}
         />

--- a/client/src/components/resources/ResourceEditForm.js
+++ b/client/src/components/resources/ResourceEditForm.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useRouter } from 'next/router'
-import { Box, Button } from 'grommet'
+import { Box } from 'grommet'
+import Button from 'components/Button'
 import useResourceForm from 'hooks/useResourceForm'
 import ResourceDetailsForm from 'components/resources/ResourceDetailsForm'
 import RequestRequirementsForm from 'components/resources/RequestRequirementsForm'
@@ -50,7 +51,7 @@ export default () => {
               validate(async () => {
                 if (await save()) {
                   clearResourceContext()
-                  router.push(`/resources/${resource.id}`)
+                  await router.push(`/resources/${resource.id}`)
                 }
               })
             }}

--- a/client/src/hooks/useTeamForm.js
+++ b/client/src/hooks/useTeamForm.js
@@ -162,11 +162,10 @@ export default () => {
         saveGrants(id),
         ...invites.map(sendEmailInvite)
       ])
-    } else {
-      return false
+      return teamRequest.response
     }
 
-    return true
+    return false
   }
 
   const leaveTeam = async (member) => {

--- a/client/src/hooks/useWaitForAsync.js
+++ b/client/src/hooks/useWaitForAsync.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export default (func) => {
+  const mountedRef = React.useRef(true)
+  const [waiting, setWaiting] = React.useState(false)
+
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false
+    },
+    []
+  )
+
+  return [
+    waiting,
+    async (...args) => {
+      if (!func) return undefined
+      let value
+      setWaiting(true)
+      if (func) {
+        value = await Promise.resolve(func(...args))
+      }
+      if (mountedRef.current) setWaiting(false)
+      return value
+    }
+  ]
+}


### PR DESCRIPTION
## Issue Number

#604 

## Purpose/Implementation Notes

* adds a new hook that returns a wrapped function and a state variable that is true when the function has been executed but not returned
* adds a new component that uses the above hook and disables the button while the callback is being executed, inherits all the same functionality as the regular grommet button and can be used indistinguishably (outside of the added functionality)
* replaces the button in the various forms with long callbacks, listing resources, creating teams
* i think most of this was due to the navigation taking a while on the stage site taking a while so i added await statements before them to keep the button disabled while those transitions occur (they should be faster in prod)
* also had the `useTeamForm` hook `save` method return the team with id so we can navigate to the resource after save

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a 
