### PR TITLE
614 open requests to open requests section

### DIFF
--- a/client/src/components/GrantRemoveButton.js
+++ b/client/src/components/GrantRemoveButton.js
@@ -146,7 +146,7 @@ export default ({ grant }) => {
               {requestedResources.map((r) => (
                 <ListItem key={r.id}>
                   <Link
-                    href={`/acccount/manage-resources/${r.id}`}
+                    href={`/account/manage-resources/${r.id}?scroll=open-requests`}
                     label={r.title}
                   />
                 </ListItem>

--- a/client/src/components/Link.js
+++ b/client/src/components/Link.js
@@ -2,10 +2,10 @@ import React from 'react'
 import Link from 'next/link'
 import { Anchor } from 'grommet'
 
-export default ({ href, label, children = '' }) => {
+export default ({ href, label, icon, as, children = '' }) => {
   return (
     <Link href={href} prefetch>
-      <Anchor href={href} label={label}>
+      <Anchor href={href} label={label} icon={icon} as={as}>
         {children}
       </Anchor>
     </Link>

--- a/client/src/components/ScrollTo.js
+++ b/client/src/components/ScrollTo.js
@@ -18,8 +18,9 @@ export default ({ name, children }) => {
     if (nameMatch && hasRef && !scrolled) {
       scrolledRef.current = true
       // TODO: this will need to be updated when responsive to account for the
-      // also this is not the best implementation of this feature since the
-      // document height is not set until after the api requests are returned
+      // fixed height of the header. Also this is not the best implementation of
+      // this feature since the document height is not set until after the api
+      // requests are returned
       setTimeout(() => {
         window.scroll(0, ref.current.offsetTop - 83)
       }, 475)

--- a/client/src/components/ScrollTo.js
+++ b/client/src/components/ScrollTo.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import { Box } from 'grommet'
+
+/*
+ * link to your component with `http://my.example.url?scroll=name`
+ * Usage: <ScrollTo name="name"> <AnyComponent /> </ScrollTo>
+ */
+
+export default ({ name, children }) => {
+  const router = useRouter()
+  const ref = React.useRef()
+  const scrolledRef = React.useRef(false)
+  React.useEffect(() => {
+    const nameMatch = name && name === router.query.scroll
+    const hasRef = !!ref.current
+    const scrolled = scrolledRef.current
+    if (nameMatch && hasRef && !scrolled) {
+      scrolledRef.current = true
+      // TODO: this will need to be updated when responsive to account for the
+      // also this is not the best implementation of this feature since the
+      // document height is not set until after the api requests are returned
+      setTimeout(() => {
+        window.scroll(0, ref.current.offsetTop - 83)
+      }, 475)
+    }
+  }, [])
+  return <Box ref={ref}>{children}</Box>
+}

--- a/client/src/components/resources/ManageResourceCard.js
+++ b/client/src/components/resources/ManageResourceCard.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Button, DropButton, Text, Anchor } from 'grommet'
-import Link from 'next/link'
+import Link from 'components/Link'
 import { useUser } from 'hooks/useUser'
 import { useAlertsQueue } from 'hooks/useAlertsQueue'
 import api from 'api'
@@ -26,31 +26,25 @@ export const ManageOptions = ({
   return (
     <Box direction={direction} gap="medium" pad={pad}>
       {options.includes('manage') && (
-        <Link href={manageLink}>
-          <Anchor
-            icon={<Icon name="Gear" size="small" />}
-            label="Manage Resource"
-            href={manageLink}
-          />
-        </Link>
+        <Link
+          icon={<Icon name="Gear" size="small" />}
+          label="Manage Resource"
+          href={manageLink}
+        />
       )}
       {options.includes('edit') && (
-        <Link href={editLink}>
-          <Anchor
-            icon={<Icon name="Edit" size="small" />}
-            label="Edit"
-            href={editLink}
-          />
-        </Link>
+        <Link
+          icon={<Icon name="Edit" size="small" />}
+          label="Edit"
+          href={editLink}
+        />
       )}
       {options.includes('view') && (
-        <Link href={viewResourceLink}>
-          <Anchor
-            icon={<Icon name="View" size="12px" />}
-            label="View Resource"
-            href={viewResourceLink}
-          />
-        </Link>
+        <Link
+          icon={<Icon name="View" size="12px" />}
+          label="View Resource"
+          href={viewResourceLink}
+        />
       )}
       {options.includes('archive') && (
         <>
@@ -87,10 +81,9 @@ export const ManageResourceCard = ({
   onChange = () => {}
 }) => {
   const { token, getTeam, isPersonalResource } = useUser()
-  const manageLink = `/account/manage-resources/${resource.id}`
+  const requestsLink = `/account/manage-resources/${resource.id}?scroll=open-requests`
   const team = getTeam(resource.organization)
   const teamLink = `/account/teams/${team.id}`
-  const viewResourceLink = `resources/${resource.id}`
 
   const [openRequests, setOpenRequests] = React.useState()
   const [dropOpen, setDropOpen] = React.useState(false)
@@ -169,9 +162,7 @@ export const ManageResourceCard = ({
       >
         {!isPersonalResource(resource) && (
           <>
-            <Link href={teamLink}>
-              <Anchor href={teamLink} label={team.name} />
-            </Link>
+            <Link href={teamLink} label={team.name} />
             <Box
               background="brand"
               round
@@ -182,9 +173,7 @@ export const ManageResourceCard = ({
           </>
         )}
         {openRequests > 0 ? (
-          <Link href={manageLink}>
-            <Anchor href={manageLink} label={`${openRequests} Open Requests`} />
-          </Link>
+          <Link href={requestsLink} label={`${openRequests} Open Requests`} />
         ) : (
           <Text>0 Open Requests</Text>
         )}
@@ -199,7 +188,11 @@ export const ManageResourceCard = ({
           <Text italic={resource.is_archived}>{archivedStatus}</Text>
         </>
       </Box>
-      <Modal showing={showArchive} setShowing={setShowArchive}>
+      <Modal
+        title="Archive Resource"
+        showing={showArchive}
+        setShowing={setShowArchive}
+      >
         <>
           {openRequests === 0 && (
             <Box>
@@ -243,33 +236,28 @@ export const ManageResourceCard = ({
             </Box>
           )}
           {openRequests !== 0 && (
-            <Box>
-              <Box direction="row">
+            <Box width="medium">
+              <Box direction="row" margin={{ vertical: 'medium' }}>
                 <Icon name="Warning" color="warning" />
                 <Text>Cannot archive resource with open requests.</Text>
               </Box>
-              <Box>
+              <Box margin={{ vertical: 'medium' }}>
                 <Text>
                   Your resource has{' '}
-                  <Link href={viewResourceLink}>
-                    <Anchor
-                      label={`${openRequests} open requests`}
-                      href={viewResourceLink}
-                    />
-                  </Link>
+                  <Link
+                    href={requestsLink}
+                    label={`${openRequests} open requests`}
+                  />
                   {'. '}
                   Please accept or reject those requests before archiving this
                   resource.
                 </Text>
               </Box>
               <Box>
-                <Link href={viewResourceLink}>
-                  <Button
-                    as="a"
-                    label="Show Requests"
-                    href={viewResourceLink}
-                  />
-                </Link>
+                <Link href={requestsLink} as="a" label="Show Requests" />
+              </Box>
+              <Box direction="row" justify="end">
+                <Button label="Close" onClick={() => setShowArchive(false)} />
               </Box>
             </Box>
           )}
@@ -277,7 +265,7 @@ export const ManageResourceCard = ({
       </Modal>
 
       <Modal showing={showDelete} setShowing={setShowDelete}>
-        <>
+        <Box>
           <Box
             border={{
               side: 'bottom',
@@ -315,7 +303,7 @@ export const ManageResourceCard = ({
               </Box>
             </Box>
           </Box>
-        </>
+        </Box>
       </Modal>
     </Box>
   )

--- a/client/src/pages/account/manage-resources/[id]/index.js
+++ b/client/src/pages/account/manage-resources/[id]/index.js
@@ -7,14 +7,16 @@ import { ManageResourceCard } from 'components/resources/ManageResourceCard'
 import { RequestRequirements } from 'components/resources/RequestRequirements'
 import ManageRequestsTable from 'components/ManageRequestsTable'
 import { Modal } from 'components/Modal'
+import ScrollTo from 'components/ScrollTo'
 import api from 'api'
 
 const ManageResource = ({ resourceId }) => {
+  const { token } = useUser()
   const [resource, setResource] = React.useState()
   const [openRequests, setOpenRequests] = React.useState([])
   const [closedRequests, setClosedRequests] = React.useState([])
   const [showClosedModal, setShowClosedModal] = React.useState(false)
-  const { token } = useUser()
+
   React.useEffect(() => {
     const fetchData = async () => {
       const resourceRequest = await api.resources.get(resourceId, token)
@@ -55,17 +57,19 @@ const ManageResource = ({ resourceId }) => {
           </Box>
           {!resource.imported && (
             <>
-              <Box>
-                <HeaderRow label={`Open Requests (${openRequests.length})`} />
-                {openRequests.length === 0 && (
-                  <Text textAlign="center" italic color="black-tint-60">
-                    There are no open requests for this resource
-                  </Text>
-                )}
-                {openRequests.length > 0 && (
-                  <ManageRequestsTable requests={openRequests} />
-                )}
-              </Box>
+              <ScrollTo name="open-requests">
+                <Box>
+                  <HeaderRow label={`Open Requests (${openRequests.length})`} />
+                  {openRequests.length === 0 && (
+                    <Text textAlign="center" italic color="black-tint-60">
+                      There are no open requests for this resource
+                    </Text>
+                  )}
+                  {openRequests.length > 0 && (
+                    <ManageRequestsTable requests={openRequests} />
+                  )}
+                </Box>
+              </ScrollTo>
               <Box>
                 <HeaderRow
                   label={`Closed Requests (${closedRequests.length})`}

--- a/client/src/pages/account/manage-resources/[id]/index.js
+++ b/client/src/pages/account/manage-resources/[id]/index.js
@@ -56,7 +56,7 @@ const ManageResource = ({ resourceId }) => {
             <RequestRequirements resource={resource} oneSection />
           </Box>
           {!resource.imported && (
-            <>
+            <Box height={{ min: '100vh' }}>
               <ScrollTo name="open-requests">
                 <Box>
                   <HeaderRow label={`Open Requests (${openRequests.length})`} />
@@ -94,7 +94,7 @@ const ManageResource = ({ resourceId }) => {
                   </>
                 )}
               </Box>
-            </>
+            </Box>
           )}
         </Box>
       )}


### PR DESCRIPTION
## Issue Number

#614 

## Purpose/Implementation Notes

If a page has a component `<ScrollTo name="open-requests" />` then linking to the page with that component with the additional query param "?scroll=open-requests" will attempt to scroll that content into view.

This works best when the `<ScrollTo />` component is inside a div or Box with it's height at min 100vh so the content can scroll entirely to to the top. I think the way we navigate to content like this should probably be revisited since it is inconsistent with how the rest of the site works. Also the scrolling will be applied when the link is shared or backwards navigation occurs which adds complexity for determining when /if that is appropriate.

This solution works 99% of the time depending on how the api responds and if the contents can render within the first and would require a much more significant lift to change the parent passes data to child paradigm that has been adhered to.


Future thoughts:
We might be able to implement something like a `useScroll` that takes an element ref and returns a function to call when it is ready to be scrolled to.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a scrolls like 99% of the time based on a conservative delay

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

![2021-03-04 11 19 28](https://user-images.githubusercontent.com/1075609/109996302-1660ee80-7cdd-11eb-9a4b-95fe8923eb33.gif)

