### PR TITLE
737 adding resource without grant

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -9,7 +9,9 @@ module.exports = () => {
     ORCID_CLIENT_ID: process.env.ORCID_CLIENT_ID,
     ORCID_URL: process.env.ORCID_URL,
     SENTRY_DSN: process.env.SENTRY_DSN,
-    SENTRY_ENV: process.env.SENTRY_ENV
+    SENTRY_ENV: process.env.SENTRY_ENV,
+    HUBSPOT_PORTAL_ID: process.env.HUBSPOT_PORTAL_ID,
+    HUBSPOT_NO_GRANT_FORM_ID: process.env.HUBSPOT_NO_GRANT_FORM_ID
   }
 
   const stageEnv = {
@@ -18,7 +20,9 @@ module.exports = () => {
     ORCID_CLIENT_ID: process.env.STAGE_ORCID_CLIENT_ID,
     ORCID_URL: process.env.STAGE_ORCID_URL,
     SENTRY_DSN: process.env.STAGE_SENTRY_DSN,
-    SENTRY_ENV: process.env.STAGE_SENTRY_ENV
+    SENTRY_ENV: process.env.STAGE_SENTRY_ENV,
+    HUBSPOT_PORTAL_ID: process.env.SATGE_HUBSPOT_PORTAL_ID,
+    HUBSPOT_NO_GRANT_FORM_ID: process.env.STAGE_HUBSPOT_NO_GRANT_FORM_ID
   }
 
   const env = isProduction ? productionEnv : stageEnv

--- a/client/src/components/GrantRequired.js
+++ b/client/src/components/GrantRequired.js
@@ -24,10 +24,7 @@ export default ({ children }) => {
       <>
         {children}
         <Modal showing nondismissable>
-          <ResourceAddNoGrantRequestForm
-            portalId="5187852"
-            formId="960eaa6e-dc9a-4921-874f-40ba9bae8583"
-          />
+          <ResourceAddNoGrantRequestForm />
         </Modal>
       </>
     )

--- a/client/src/components/GrantRequired.js
+++ b/client/src/components/GrantRequired.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import ResourceAddNoGrantRequestForm from 'components/ResourceAddNoGrantRequestForm'
+import { Loader } from 'components/Loader'
+import { useUser } from 'hooks/useUser'
+
+import { Modal } from 'components/Modal'
+
+export default ({ children }) => {
+  const { isAbleToAddResources } = useUser()
+  const [userOk, setUserOk] = React.useState()
+
+  React.useEffect(() => {
+    const asyncCheck = async () => {
+      setUserOk(await isAbleToAddResources())
+    }
+    if (userOk === undefined) asyncCheck()
+  })
+
+  if (userOk === undefined) return <Loader />
+
+  // show feature request form if user does not have a grant
+  if (!userOk) {
+    return (
+      <>
+        {children}
+        <Modal showing nondismissable>
+          <ResourceAddNoGrantRequestForm
+            portalId="5187852"
+            formId="960eaa6e-dc9a-4921-874f-40ba9bae8583"
+          />
+        </Modal>
+      </>
+    )
+  }
+
+  return children
+}

--- a/client/src/components/ResourceAddNoGrantRequestForm.js
+++ b/client/src/components/ResourceAddNoGrantRequestForm.js
@@ -11,12 +11,14 @@ import {
 import { useRouter } from 'next/router'
 import Icon from 'components/Icon'
 import Button from 'components/Button'
+import ResourceFormFieldLabel from 'components/resources/ResourceFormFieldLabel'
 import FormFieldErrorLabel from 'components/FormFieldErrorLabel'
 import { useAlertsQueue } from 'hooks/useAlertsQueue'
 import useHubspotForm from 'hooks/useHubspotForm'
 import formSchema from 'schemas/resourceAddNoGrantRequest'
 
 export default ({ portalId, formId, onCancel, onSubmit }) => {
+  const anythingElse = 'Is there anything else you would like to add?'
   const { addAlert } = useAlertsQueue()
   const [sent, setSent] = React.useState()
   const router = useRouter()
@@ -147,7 +149,7 @@ export default ({ portalId, formId, onCancel, onSubmit }) => {
           />
         </FormField>
         <FormField
-          label="Is there anything else you would like to add?"
+          label={<ResourceFormFieldLabel optional attribute={anythingElse} />}
           error={getError('additional_info__adding_resources_without_grant_id')}
         >
           <TextArea

--- a/client/src/components/ResourceAddNoGrantRequestForm.js
+++ b/client/src/components/ResourceAddNoGrantRequestForm.js
@@ -1,0 +1,182 @@
+import React from 'react'
+import {
+  Anchor,
+  Box,
+  Text,
+  FormField,
+  Paragraph,
+  TextArea,
+  TextInput
+} from 'grommet'
+import { useRouter } from 'next/router'
+import Icon from 'components/Icon'
+import Button from 'components/Button'
+import FormFieldErrorLabel from 'components/FormFieldErrorLabel'
+import { useAlertsQueue } from 'hooks/useAlertsQueue'
+import useHubspotForm from 'hooks/useHubspotForm'
+import formSchema from 'schemas/resourceAddNoGrantRequest'
+
+export default ({ portalId, formId, onCancel, onSubmit }) => {
+  const { addAlert } = useAlertsQueue()
+  const [sent, setSent] = React.useState()
+  const router = useRouter()
+  const {
+    getAttribute,
+    setAttribute,
+    submit,
+    validate,
+    errors,
+    hasError
+  } = useHubspotForm(portalId, formId)
+  const handleSubmit = async () => {
+    const valid = await validate(formSchema)
+    if (valid) {
+      const submitRequest = await submit()
+
+      if (submitRequest.isOk) {
+        addAlert('Request submitted successfully', 'success')
+        setSent(true)
+        if (onSubmit) onSubmit()
+        router.push('/')
+      } else {
+        addAlert('Unable to save please try again later', 'error')
+      }
+    }
+  }
+
+  const handleCancel = () => {
+    if (onCancel) onCancel()
+    router.push('/')
+  }
+
+  const getError = (attribute) => {
+    if (errors[attribute]) {
+      return <FormFieldErrorLabel message={errors[attribute]} />
+    }
+    return false
+  }
+
+  if (sent) {
+    return (
+      <Box
+        height={{ min: 'min-content' }}
+        pad={{ bottom: 'medium' }}
+        margin={{ bottom: 'medium' }}
+        direction="row"
+      >
+        <Text margin={{ top: '2px', right: '4px' }}>
+          <Icon name="Check" color="success" />
+        </Text>
+        <Text serif size="large">
+          Message Sent!
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <>
+      <Box
+        border={{
+          side: 'bottom',
+          color: 'border-black',
+          size: 'small'
+        }}
+        height={{ min: 'min-content' }}
+        pad={{ bottom: 'medium' }}
+        margin={{ bottom: 'medium' }}
+        direction="row"
+      >
+        <Text margin={{ top: '2px', right: '4px' }}>
+          <Icon name="Warning" color="error" />
+        </Text>
+        <Text serif size="large">
+          Not Supported - Adding Resource without a Grant ID.
+        </Text>
+      </Box>
+      <Box>
+        <Paragraph>
+          We currently only support adding a resource with an{' '}
+          <Text weight="bold">ALSF Grant</Text>. If you have an ALSF grant,
+          please reach out to the{' '}
+          <Anchor label="Grants Team" href="mailto:grants@alexslemonade.org" />{' '}
+          for an invite.
+        </Paragraph>
+      </Box>
+      <Box>
+        <Paragraph>
+          We are trying gauge interest from researchers without an ALSF Grant in
+          sharing resources via the CCRR portal. If you are interested, please
+          fill out the form below and we will let you know when this feature
+          becomes available.
+        </Paragraph>
+      </Box>
+      <Box>
+        <Box direction="row" gap="medium">
+          <FormField
+            label="First Name"
+            error={getError('firstname')}
+            width="full"
+          >
+            <TextInput
+              value={getAttribute('firstname') || ''}
+              onChange={({ target: { value } }) => {
+                setAttribute('firstname', value)
+              }}
+            />
+          </FormField>
+          <FormField
+            label="Last Name"
+            error={getError('lastname')}
+            width="full"
+          >
+            <TextInput
+              value={getAttribute('lastname') || ''}
+              onChange={({ target: { value } }) => {
+                setAttribute('lastname', value)
+              }}
+            />
+          </FormField>
+        </Box>
+        <FormField label="Email" error={getError('email')}>
+          <TextInput
+            value={getAttribute('email') || ''}
+            onChange={({ target: { value } }) => {
+              setAttribute('email', value)
+            }}
+          />
+        </FormField>
+        <FormField
+          label="Is there anything else you would like to add?"
+          error={getError('additional_info__adding_resources_without_grant_id')}
+        >
+          <TextArea
+            value={getAttribute(
+              'additional_info__adding_resources_without_grant_id'
+            )}
+            onChange={({ target: { value } }) => {
+              setAttribute(
+                'additional_info__adding_resources_without_grant_id',
+                value
+              )
+            }}
+          />
+        </FormField>
+      </Box>
+      <Box
+        direction="row"
+        justify="end"
+        gap="medium"
+        margin={{ vertical: 'medium' }}
+      >
+        <Button label="Cancel" onClick={handleCancel} />
+        <Button
+          primary
+          label="Submit"
+          onClick={handleSubmit}
+          disabled={hasError}
+        />
+      </Box>
+    </>
+  )
+}

--- a/client/src/components/ResourceAddNoGrantRequestForm.js
+++ b/client/src/components/ResourceAddNoGrantRequestForm.js
@@ -17,11 +17,13 @@ import { useAlertsQueue } from 'hooks/useAlertsQueue'
 import useHubspotForm from 'hooks/useHubspotForm'
 import formSchema from 'schemas/resourceAddNoGrantRequest'
 
-export default ({ portalId, formId, onCancel, onSubmit }) => {
+export default ({ onCancel, onSubmit }) => {
   const anythingElse = 'Is there anything else you would like to add?'
   const { addAlert } = useAlertsQueue()
   const [sent, setSent] = React.useState()
   const router = useRouter()
+  const portalId = process.env.HUBSPOT_PORTAL_ID
+  const formId = process.env.HUBSPOT_NO_GRANT_FORM_ID
   const {
     getAttribute,
     setAttribute,

--- a/client/src/hooks/useHubspotForm.js
+++ b/client/src/hooks/useHubspotForm.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import request from 'helpers/request'
+import getErrorMessages from 'helpers/getErrorMessages'
+
+export default (portalId, formId) => {
+  const [formData, setFormData] = React.useState({})
+  const [errors, setErrors] = React.useState({})
+
+  const apiBase = 'https://api.hsforms.com/submissions/v3/integration/submit'
+  const endpoint = `${apiBase}/${portalId}/${formId}`
+
+  const getAttribute = (attribute) => formData[attribute]
+
+  const setAttribute = (attribute, value) => {
+    resetError(attribute)
+    const newFormData = { ...formData }
+    newFormData[attribute] = value
+    setFormData(newFormData)
+  }
+
+  // helper for slowly removing errors from the error obj
+  const resetError = (attribute) => {
+    if (attribute in errors) {
+      const newErrors = { ...errors }
+      delete newErrors[attribute]
+      setErrors(newErrors)
+    }
+  }
+
+  // take a schema from /schemas test it and set errors from helper
+  // call this before submit()
+  const validate = async (schema) => {
+    try {
+      await schema.validate(formData, { abortEarly: false })
+    } catch (e) {
+      setErrors(getErrorMessages(e))
+      return false
+    }
+
+    return true
+  }
+
+  // can't just post the json data, no that would be too easy
+  // convert to {fields: [{name, value}]}
+  const submit = async () => {
+    const fields = Object.keys(formData).map((f) => ({
+      name: f,
+      value: getAttribute(f)
+    }))
+    return request(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({ fields })
+    })
+  }
+
+  // helper for knowing when to disable the button
+  const hasError = Object.keys(errors).length !== 0
+
+  return {
+    getAttribute,
+    setAttribute,
+    submit,
+    validate,
+    errors,
+    hasError
+  }
+}

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -125,7 +125,7 @@ export const useUser = (defaultUser, defaultToken) => {
 
     const hasGrants = grants.length > 0
     // join all the arrays of org grants to one array and check if empty
-    const hasTeamGrants = [].concat(...teams.map((t) => t.g)).length > 0
+    const hasTeamGrants = [].concat(...teams.map((t) => t.grants)).length > 0
 
     return hasGrants || hasTeamGrants
   }

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -110,6 +110,26 @@ export const useUser = (defaultUser, defaultToken) => {
     return request.assigned_to.id === user.id
   }
 
+  const isAbleToAddResources = async () => {
+    if (!isLoggedIn) return false
+
+    const { response: freshUser, isOk: userIsOk } = await api.users.get(
+      user.id,
+      token
+    )
+
+    if (!userIsOk) return false
+
+    // user has grants
+    const { grants, organizations: teams } = freshUser
+
+    const hasGrants = grants.length > 0
+    // join all the arrays of org grants to one array and check if empty
+    const hasTeamGrants = [].concat(...teams.map((t) => t.g)).length > 0
+
+    return hasGrants || hasTeamGrants
+  }
+
   return {
     user,
     setUser,
@@ -124,6 +144,7 @@ export const useUser = (defaultUser, defaultToken) => {
     getTeam,
     isPersonalResource,
     isResourceRequester,
-    isAssignedRequest
+    isAssignedRequest,
+    isAbleToAddResources
   }
 }

--- a/client/src/pages/resources/import.js
+++ b/client/src/pages/resources/import.js
@@ -3,6 +3,10 @@ import dynamic from 'next/dynamic'
 import { Heading } from 'grommet'
 import { ResourceContextProvider } from 'contexts/ResourceContext'
 
+const GrantRequired = dynamic(() => import('components/GrantRequired'), {
+  ssr: false
+})
+
 const LoginRequired = dynamic(() => import('components/LoginRequired'), {
   ssr: false
 })
@@ -15,12 +19,14 @@ const ImportResource = dynamic(
 export const ResourcesImport = () => {
   return (
     <LoginRequired title="You Must Login To Import a Resource">
-      <ResourceContextProvider localStorageName="import-resource">
-        <Heading level={4} serif>
-          Import a Resource
-        </Heading>
-        <ImportResource />
-      </ResourceContextProvider>
+      <GrantRequired>
+        <ResourceContextProvider localStorageName="import-resource">
+          <Heading level={4} serif>
+            Import a Resource
+          </Heading>
+          <ImportResource />
+        </ResourceContextProvider>
+      </GrantRequired>
     </LoginRequired>
   )
 }

--- a/client/src/pages/resources/list.js
+++ b/client/src/pages/resources/list.js
@@ -2,6 +2,9 @@ import React from 'react'
 import dynamic from 'next/dynamic'
 import { ResourceContextProvider } from 'contexts/ResourceContext'
 
+const GrantRequired = dynamic(() => import('components/GrantRequired'), {
+  ssr: false
+})
 const LoginRequired = dynamic(() => import('components/LoginRequired'), {
   ssr: false
 })
@@ -11,13 +14,13 @@ const ResourceForm = dynamic(
   { ssr: false }
 )
 export const ResourcesList = () => {
-  // TODO:
-  // - prevent people with no grants
   return (
     <LoginRequired title="You Must Login To List a Resource">
-      <ResourceContextProvider localStorageName="list-resource">
-        <ResourceForm />
-      </ResourceContextProvider>
+      <GrantRequired>
+        <ResourceContextProvider localStorageName="list-resource">
+          <ResourceForm />
+        </ResourceContextProvider>
+      </GrantRequired>
     </LoginRequired>
   )
 }

--- a/client/src/schemas/resourceAddNoGrantRequest.js
+++ b/client/src/schemas/resourceAddNoGrantRequest.js
@@ -1,0 +1,8 @@
+import { object, string } from 'yup'
+
+export default object({
+  firstname: string().required('Please enter your first name.'),
+  lastname: string().required('Please enter your last name.'),
+  email: string().email().required('Please enter your email.'),
+  additional_info__adding_resources_without_grant_id: string()
+})


### PR DESCRIPTION
## Issue Number

#737 

## Purpose/Implementation Notes

* adds a generic hook to talking to hubspot api
* adds a `GrantsRequired` guard that forced the feature request form if user's account does not have any grants
* `GrantsRequired` runs after `AccountRequired` so as it stands right now they would have to login to find out they cant post without a grant.
* validates the input which is handled by the hook using generic helpers (very cool) and takes an arbitrary form schema
* alerts user to success/errors and redirects them home when they are done

NOTE: if the hubspot form updates, we will need to update the form component to match expected inputs... there was no way to use the embed code in a way that would suit our needs.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested validation, successful response, and bad response all seem to be working as expected

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![Screen Shot 2021-03-19 at 4 05 35 PM](https://user-images.githubusercontent.com/1075609/111836628-fd576080-88cc-11eb-8e73-df53afeb4176.png)
![Screen Shot 2021-03-19 at 4 06 16 PM](https://user-images.githubusercontent.com/1075609/111836662-09dbb900-88cd-11eb-8555-b59676ef5e16.png)

Updated:

![Screen Shot 2021-03-19 at 4 41 15 PM](https://user-images.githubusercontent.com/1075609/111840000-17e00880-88d2-11eb-9def-50cfd20cee6d.png)


