### PR TITLE
Fixes typo in notifications markdown

### DIFF
--- a/api/resources_portal/models/notifications_config.py
+++ b/api/resources_portal/models/notifications_config.py
@@ -343,7 +343,7 @@ NOTIFICATION_CONFIGS = {
             "\n\nView request details. ({request_url})."
         ),
         "markdown": (
-            "{requester_name} has reported an issue with a fulfilled [request]({requst_path})"
+            "{requester_name} has reported an issue with a fulfilled [request]({request_path})"
             " for [{material_name}]({material_path}).\n\n{issue_description}"
         ),
         "required_associations": [


### PR DESCRIPTION
## Issue Number

Saw this error in the logs while checking why Deepa's UE didn't receive emails (turned out he used the wrong email).

## Purpose/Implementation Notes

Just fixes the typo.
