### PR TITLE
790 import dataset is not a source

### DIFF
--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -63,6 +63,9 @@ export const useUser = (defaultUser, defaultToken) => {
   const logOut = () => {
     setUser()
     setToken()
+    // remove all localStorage keys
+    // this will prevent cross contaminating user sessions
+    window.localStorage.clear()
     router.push('/')
   }
 

--- a/client/src/schemas/material.js
+++ b/client/src/schemas/material.js
@@ -25,7 +25,6 @@ export const importSources = [
   'GEO',
   'SRA',
   'DBGAP',
-  'DATASET',
   'PROTOCOLS_IO',
   'ADDGENE',
   'JACKSON_LABS',


### PR DESCRIPTION
## Issue Number

#790 

## Purpose/Implementation Notes

Dataset isn't an import source it was a category that was copied over erroneously.

* removes dataset from list of import sources
* cleans out localStorage on logout -> this is how you can fix your session

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a triggered the error and was able to list after logging out and logging back in

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
