### PR TITLE
Add duplicate resources for ones that won't cleanly cycle themselves.

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -15,6 +15,22 @@ resource "aws_db_parameter_group" "postgres_parameters" {
     name = "statement_timeout"
     value = "60000" # 60000ms = 60s
   }
+}
+
+resource "aws_db_parameter_group" "postgres_parameters_new" {
+  name = "resources-portal-postgres-parameters-${var.user}-${var.stage}-new"
+  description = "Postgres Parameters ${var.user} ${var.stage}"
+  family = "postgres9.6"
+
+  parameter {
+    name = "deadlock_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  parameter {
+    name = "statement_timeout"
+    value = "60000" # 60000ms = 60s
+  }
 
   tags = var.default_tags
 }

--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -49,7 +49,7 @@ resource "aws_db_instance" "postgres_db" {
   password = var.database_password
 
   db_subnet_group_name = aws_db_subnet_group.resources_portal.name
-  parameter_group_name = aws_db_parameter_group.postgres_parameters.name
+  parameter_group_name = aws_db_parameter_group.postgres_parameters_new.name
 
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -141,6 +141,19 @@ resource "aws_lb" "resources_portal_api_load_balancer" {
   tags = var.default_tags
 }
 
+resource "aws_lb_target_group" "api-http-old" {
+  name = "dr-api-${var.user}-${var.stage}-http"
+  port = 80
+  protocol = "TCP"
+  vpc_id = aws_vpc.resources_portal_vpc.id
+  stickiness {
+    enabled = false
+    type = "source_ip"
+  }
+
+  tags = var.default_tags
+}
+
 resource "aws_lb_target_group" "api-http" {
   name = "rp-api-${var.user}-${var.stage}-http"
   port = 80
@@ -169,6 +182,19 @@ resource "aws_lb_target_group_attachment" "api-http" {
   target_group_arn = aws_lb_target_group.api-http.arn
   target_id = aws_instance.api_server_1.id
   port = 80
+}
+
+resource "aws_lb_target_group" "api-https-old" {
+  name = "dr-api-${var.user}-${var.stage}-https"
+  port = 443
+  protocol = "TCP"
+  vpc_id = aws_vpc.resources_portal_vpc.id
+  stickiness {
+    enabled = false
+    type = "source_ip"
+  }
+
+  tags = var.default_tags
 }
 
 resource "aws_lb_target_group" "api-https" {


### PR DESCRIPTION
## Issue Number

#835 

## Purpose/Implementation Notes

The deploy failed with:
```
Error: Error deleting DB parameter group: InvalidDBParameterGroupState: One or more database instances are still members of this parameter group postgres-parameters-deployer-staging, so the group cannot be deleted
	status code: 400, request id: 1bf30bee-97ee-4311-abb3-185c68a8d9ec



Error: error deleting Target Group: ResourceInUse: Target group 'arn:aws:elasticloadbalancing:us-east-1:589864003899:targetgroup/dr-api-deployer-staging-http/ab732ef807c56e56' is currently in use by a listener or a rule
	status code: 400, request id: d5a7f717-3845-4d30-af93-d10eefc6fab1



Error: error deleting Target Group: ResourceInUse: Target group 'arn:aws:elasticloadbalancing:us-east-1:589864003899:targetgroup/dr-api-deployer-staging-https/c698a9e25dc4c417' is currently in use by a listener or a rule
	status code: 400, request id: 61411bde-fcd5-41a3-89a5-6fbc221f93c0
```

I think it's because adding the tags and changing the names requires a new resource, but AWS/terraform can't just swap them out so I have to add a new resource to use, then later delete the old resource once it's unused.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
