### PR TITLE
Tweak resource names for database parameter groups

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -2,7 +2,7 @@
 # postgres RDS instance.
 
 # Currently exists, will be deleted after aws_db_parameter_group.postgres_parameters is in use.
-resource "aws_db_parameter_group" "postgres_parameters_old" {
+resource "aws_db_parameter_group" "postgres_parameters" {
   name = "postgres-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
   family = "postgres9.6"
@@ -18,7 +18,7 @@ resource "aws_db_parameter_group" "postgres_parameters_old" {
   }
 }
 
-resource "aws_db_parameter_group" "postgres_parameters" {
+resource "aws_db_parameter_group" "postgres_parameters_new" {
   name = "resources-portal-postgres-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
   family = "postgres9.6"
@@ -50,7 +50,7 @@ resource "aws_db_instance" "postgres_db" {
   password = var.database_password
 
   db_subnet_group_name = aws_db_subnet_group.resources_portal.name
-  parameter_group_name = aws_db_parameter_group.postgres_parameters.name
+  parameter_group_name = aws_db_parameter_group.postgres_parameters_new.name
 
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417


### PR DESCRIPTION
## Issue Number

#836 

## Purpose/Implementation Notes

Ok so apparently resource names are important to terraform.
