### PR TITLE
remove brand color issue from suggestions onmouseexit

### DIFF
--- a/client/src/theme/index.js
+++ b/client/src/theme/index.js
@@ -183,7 +183,10 @@ const theme = {
           `
         ),
         applyWhen(
-          props.plain && !props.role && !props.colorValue,
+          props.plain &&
+            !props.role &&
+            !props.colorValue &&
+            !(props.hoverIndicator === 'background'), // exclude suggestions
           `
           color: ${normalizeColor('brand', props.theme)};
 


### PR DESCRIPTION
## Issue Number

#851 

## Purpose/Implementation Notes

* excludes the suggestions from being grouped into the plain button rules to prevent the blue text on blue background issue
* annoyingly this means that i was unable to make the suggestions text from being the brand color.... but i dont think it's worth the added effort to rewrite the rules to make this work at this time.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested on the teams section when adding a member should apply universally to all textInputs in the same way

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-05-18 at 4 58 29 PM](https://user-images.githubusercontent.com/1075609/118722860-ae5d7700-b7fa-11eb-8d66-3f7ef2fb560e.png)
![Screen Shot 2021-05-18 at 5 01 38 PM](https://user-images.githubusercontent.com/1075609/118722913-bc12fc80-b7fa-11eb-93a7-007085211695.png)

