### PR TITLE
816 uncheckable weekly digest

### DIFF
--- a/api/resources_portal/views/user.py
+++ b/api/resources_portal/views/user.py
@@ -92,6 +92,8 @@ class UserSerializer(serializers.ModelSerializer):
             "email",
             "orcid",
             "viewed_notifications_at",
+            "receive_non_assigned_notifs",
+            "receive_weekly_digest",
             "owned_attachments",
             "material_requests",
             "grants",

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -75,6 +75,32 @@ export const useUser = (defaultUser, defaultToken) => {
     return updateRequest.isOk
   }
 
+  const updateReceiveNonAssignedNotifs = async (isNotified) => {
+    const updateRequest = await api.users.update(
+      user.id,
+      { receive_non_assigned_notifs: isNotified },
+      token
+    )
+    if (updateRequest.isOk) {
+      refreshUser()
+      addAlert('Successfully updated', 'success')
+    }
+    return updateRequest.isOk
+  }
+
+  const updateReceiveWeeklyDigest = async (isNotified) => {
+    const updateRequest = await api.users.update(
+      user.id,
+      { receive_weekly_digest: isNotified },
+      token
+    )
+    if (updateRequest.isOk) {
+      refreshUser()
+      addAlert('Successfully updated', 'success')
+    }
+    return updateRequest.isOk
+  }
+
   const getTeam = (teamOrId) => {
     const teamId = teamOrId.id || teamOrId
     if (user.organizations) {
@@ -143,6 +169,8 @@ export const useUser = (defaultUser, defaultToken) => {
     fetchUserWithNewToken,
     refreshUser,
     updateEmail,
+    updateReceiveNonAssignedNotifs,
+    updateReceiveWeeklyDigest,
     logOut,
     getTeam,
     isPersonalResource,

--- a/client/src/hooks/useUser.js
+++ b/client/src/hooks/useUser.js
@@ -84,6 +84,8 @@ export const useUser = (defaultUser, defaultToken) => {
     if (updateRequest.isOk) {
       refreshUser()
       addAlert('Successfully updated', 'success')
+    } else {
+      addAlert('Unable to update at this time', 'error')
     }
     return updateRequest.isOk
   }
@@ -97,6 +99,8 @@ export const useUser = (defaultUser, defaultToken) => {
     if (updateRequest.isOk) {
       refreshUser()
       addAlert('Successfully updated', 'success')
+    } else {
+      addAlert('Unable to update at this time', 'error')
     }
     return updateRequest.isOk
   }

--- a/client/src/pages/account/notifications/settings.js
+++ b/client/src/pages/account/notifications/settings.js
@@ -3,8 +3,52 @@ import { Box } from 'grommet'
 import { DrillDownNav } from 'components/DrillDownNav'
 import { HeaderRow } from 'components/HeaderRow'
 import { CheckBoxWithInfo } from 'components/CheckBoxWithInfo'
+import { useUser } from 'hooks/useUser'
 
 export const Settings = () => {
+  const {
+    user,
+    refreshUser,
+    isLoggedIn,
+    updateReceiveNonAssignedNotifs,
+    updateReceiveWeeklyDigest
+  } = useUser()
+
+  const [nonAssignedNotifs, setNonAssignedNotifs] = React.useState(
+    user.receive_non_assigned_notifs
+  )
+  const [weeklyDigest, setWeeklyDigest] = React.useState(
+    user.reveive_weekly_digest
+  )
+
+  React.useEffect(() => {
+    if (isLoggedIn) refreshUser()
+  }, [])
+
+  React.useEffect(() => {
+    const asyncUpdate = async () => {
+      const success = updateReceiveNonAssignedNotifs(nonAssignedNotifs)
+      if (!success) {
+        setNonAssignedNotifs(user.receive_non_assigned_notifs)
+      }
+    }
+    if (nonAssignedNotifs !== user.non_assigned_notifs) {
+      asyncUpdate()
+    }
+  }, [nonAssignedNotifs])
+
+  React.useEffect(() => {
+    const asyncUpdate = async () => {
+      const success = updateReceiveWeeklyDigest(weeklyDigest)
+      if (!success) {
+        setWeeklyDigest(user.receive_weekly_digest)
+      }
+    }
+    if (weeklyDigest !== user.receive_weekly_digest) {
+      asyncUpdate()
+    }
+  }, [weeklyDigest])
+
   return (
     <DrillDownNav
       title="Notification Settings"
@@ -22,13 +66,16 @@ export const Settings = () => {
         </Box>
         <Box margin={{ top: 'large' }}>
           <CheckBoxWithInfo
+            checked={nonAssignedNotifs}
+            onChange={(event) => setNonAssignedNotifs(event.target.checked)}
             label="Send updates all times"
             info="You will receive real-time email updates about requests and new team members for all teams you are a part of."
           />
         </Box>
         <Box margin={{ top: 'large' }}>
           <CheckBoxWithInfo
-            checked
+            checked={weeklyDigest}
+            onChange={(event) => setWeeklyDigest(event.target.checked)}
             label="Send me a weekly digest of updates"
             info="You will recieve email updates about requests, resources, and teams you are part of once a week."
           />


### PR DESCRIPTION
## Issue Number

#816 

## Purpose/Implementation Notes

* adds `reveive_non_assigned_notifs` and `receive_weekly_digest` to the user serializer
* adds methods to update those settings in the `useUser` hook
* connects them to the checkboxes on the notification settings page

Note: we have to deploy this to test on staging because the settings are not exposed at the moment

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested toggling options

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
