### PR TITLE
808 add messaging to start urls with protocol

### DIFF
--- a/client/src/helpers/getHelperText.js
+++ b/client/src/helpers/getHelperText.js
@@ -8,7 +8,8 @@ export const helperTexts = {
   purpose: `What does this plasmid do?`,
   relevant_mutations: `Mention any mutations in the gene/insert`,
   sequence_maps: `Upload the full sequence and partial sequence maps. You can generate sequence maps [here](http://wishart.biology.ualberta.ca/PlasMapper/).`,
-  str_profile: `You obtain an STR profile for your cell line [here](https://www.atcc.org/en/Services/Testing_Services.aspx).`
+  str_profile: `You obtain an STR profile for your cell line [here](https://www.atcc.org/en/Services/Testing_Services.aspx).`,
+  url: 'Urls must start with **http**. (ex: https://alexslemonade.org)'
 }
 
 export default (attribute) => {


### PR DESCRIPTION
## Issue Number

#808 

## Purpose/Implementation Notes

* adds helper text for url attributes to start urls with `http`

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

viewed locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots


![Screen Shot 2021-05-19 at 12 05 15 PM](https://user-images.githubusercontent.com/1075609/118846507-c4227900-b89a-11eb-9e00-d4d72d8b6857.png)

