### PR TITLE
806 removes empty organisms on save

### DIFF
--- a/client/src/hooks/useResourceForm.js
+++ b/client/src/hooks/useResourceForm.js
@@ -277,6 +277,11 @@ export default () => {
     delete saveResource.sequence_maps
     delete saveResource.grants
 
+    // remove empty organisms
+    if (saveResource.organisms) {
+      saveResource.organisms = saveResource.organisms.filter((o) => Boolean(o))
+    }
+
     if (existingRequirementsResource.id) {
       // apply requirements from existing resource
       saveResource.needs_abstract = existingRequirementsResource.needs_abstract


### PR DESCRIPTION
## Issue Number

#806 

## Purpose/Implementation Notes

* filters out empty organisms on save
* does not filter out for preview... it didnt seem appropriate to change data during validation

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested listing with an extra empty organism

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a basically imagine everything exactly the same but on the preview there is a trailing comma and then on the resource page there is no trailing comma
