### PR TITLE
go to top of page when request is refreshed

### DIFF
--- a/client/src/contexts/RequestContext.js
+++ b/client/src/contexts/RequestContext.js
@@ -15,6 +15,10 @@ export const RequestContextProvider = ({ requestId, children }) => {
     if (requestRequest.isOk) {
       fetchedRef.current = true
       setRequest(requestRequest.response)
+      // scroll to top of page when we refresh the request
+      window.scrollTo({
+        top: 0
+      })
     } else {
       fetchedRef.current = false
       // since requests can never be deleted we should


### PR DESCRIPTION
## Issue Number

#828 

## Purpose/Implementation Notes

* when we refresh the request because something has changed, move the window to the top of the page to see the new state.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
