### PR TITLE
Api Endpoints with optional trailing slashes

### DIFF
--- a/api/resources_portal/urls.py
+++ b/api/resources_portal/urls.py
@@ -40,6 +40,8 @@ from resources_portal.views import (
 )
 
 router = ExtendedSimpleRouter()
+router.trailing_slash = "/?"
+
 router.register(r"users", UserViewSet, basename="user")
 router.register(r"users", UserViewSet, basename="user").register(
     r"organizations",
@@ -54,6 +56,7 @@ router.register(r"users", UserViewSet, basename="user").register(
     r"addresses", AddressViewSet, basename="users-addresses", parents_query_lookups=["user"],
 )
 
+router.register(r"organizations", OrganizationViewSet, basename="organization")
 router.register(r"organizations", OrganizationViewSet, basename="organization").register(
     r"members",
     OrganizationMemberViewSet,


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Overwrites the trialing slash regex to match regardless of whether there is a trailing slash or not.
Note: This was because the local and staging envs were behaving differently. So while this is a good solution because we wanted optional slashes anyway... it does not explain the difference of behavior between two envs that should have been behaving the same.

Also adds in the solo organizations url to viewset register.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested the org update endpoint with and without a trailing slash

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
