### PR TITLE
stop saving updates before interaction

### DIFF
--- a/client/src/pages/account/notifications/settings.js
+++ b/client/src/pages/account/notifications/settings.js
@@ -14,6 +14,7 @@ export const Settings = () => {
     updateReceiveWeeklyDigest
   } = useUser()
 
+  const readyRef = React.useRef(false)
   const [nonAssignedNotifs, setNonAssignedNotifs] = React.useState(
     user.receive_non_assigned_notifs
   )
@@ -22,7 +23,11 @@ export const Settings = () => {
   )
 
   React.useEffect(() => {
-    if (isLoggedIn) refreshUser()
+    const refresh = async () => {
+      await refreshUser()
+      readyRef.current = true
+    }
+    if (isLoggedIn) refresh()
   }, [])
 
   React.useEffect(() => {
@@ -32,7 +37,7 @@ export const Settings = () => {
         setNonAssignedNotifs(user.receive_non_assigned_notifs)
       }
     }
-    if (nonAssignedNotifs !== user.non_assigned_notifs) {
+    if (readyRef.current && nonAssignedNotifs !== user.non_assigned_notifs) {
       asyncUpdate()
     }
   }, [nonAssignedNotifs])
@@ -44,7 +49,7 @@ export const Settings = () => {
         setWeeklyDigest(user.receive_weekly_digest)
       }
     }
-    if (weeklyDigest !== user.receive_weekly_digest) {
+    if (readyRef.current && weeklyDigest !== user.receive_weekly_digest) {
       asyncUpdate()
     }
   }, [weeklyDigest])


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

* fixes an issue where after the user refresh happens it would trigger a save since it detected a change

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a - loads the page without the saving event firing but toggling will save the changes

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
