### PR TITLE
831 fix redirect after login

### DIFF
--- a/client/src/ResourcesPortalContext.js
+++ b/client/src/ResourcesPortalContext.js
@@ -10,6 +10,10 @@ export const ResourcesPortalContextProvider = ({ children }) => {
   const [alertsQueues, setAlertsQueues] = React.useState({})
   const [notificationCount, setNotificationCount] = React.useState(0)
 
+  // used to prevent default redirect after login in pages/account/index.js
+  // updated by useCreateUser login flow
+  const skipAccountRedirectRef = React.useRef(false)
+
   return (
     <ResourcesPortalContext.Provider
       value={{
@@ -22,7 +26,8 @@ export const ResourcesPortalContextProvider = ({ children }) => {
         alertsQueues,
         setAlertsQueues,
         notificationCount,
-        setNotificationCount
+        setNotificationCount,
+        skipAccountRedirectRef
       }}
     >
       {children}

--- a/client/src/hooks/useCreateUser.js
+++ b/client/src/hooks/useCreateUser.js
@@ -5,6 +5,7 @@ import { useUser } from 'hooks/useUser'
 import api from 'api'
 import getRedirectQueryParam from 'helpers/getRedirectQueryParam'
 import arraysMatch from 'helpers/arraysMatch'
+import { ResourcesPortalContext } from 'ResourcesPortalContext'
 
 export const useCreateUser = (code, clientPath) => {
   const router = useRouter()
@@ -24,6 +25,8 @@ export const useCreateUser = (code, clientPath) => {
     setError,
     clientRedirectUrl
   } = React.useContext(CreateUserContext)
+
+  const { skipAccountRedirectRef } = React.useContext(ResourcesPortalContext)
 
   React.useEffect(() => {
     const asyncGetORCID = async () => {
@@ -58,6 +61,9 @@ export const useCreateUser = (code, clientPath) => {
       clientRedirectUrl &&
       !clientRedirectUrl.includes('create-account')
     ) {
+      // allow this action to take place
+      // by skipping the default account -> basic-information redirect
+      skipAccountRedirectRef.current = true
       router.replace(clientRedirectUrl)
     }
 

--- a/client/src/pages/account/index.js
+++ b/client/src/pages/account/index.js
@@ -1,16 +1,20 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 import { Loader } from 'components/Loader'
+import { ResourcesPortalContext } from 'ResourcesPortalContext'
 
 // This page currently has no content.
 // Show loader then redirect to basic info
 
 export default () => {
   const router = useRouter()
-
+  const { skipAccountRedirectRef } = React.useContext(ResourcesPortalContext)
   React.useEffect(() => {
-    router.replace('/account/basic-information')
-  })
+    if (!skipAccountRedirectRef.current) {
+      router.replace('/account/basic-information')
+    }
+    skipAccountRedirectRef.current = false
+  }, [])
 
   return <Loader />
 }


### PR DESCRIPTION
## Issue Number

#831 

## Purpose/Implementation Notes

* adds a flag ref in the `ResourcesPortalContext` that determines if /account should do the temp redirect

The `account/index` page has a temporary redirect to `account/basic-information`. This was firing after the redirect to the place the use left off before signing in which was overriding that functionality. This PR adds a flag to ignore that temp redirect if they just logged in. It's not great but it works and will be removed when that page no longer has the redirect on it.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a 
* tested logging in from search and went back there
* tested the /account link and was redirected to basic-information
* tested with create-account flow

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
