### PR TITLE
871 search pagination is offset based not page based

### DIFF
--- a/client/src/components/SearchResultsLimit.js
+++ b/client/src/components/SearchResultsLimit.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Select, Paragraph } from 'grommet'
+import { Box, Paragraph, Select, Text } from 'grommet'
 import { useSearchResources } from '../hooks/useSearchResources'
 
 export const limitOptions = ['10', '25', '50', '100']
@@ -9,6 +9,7 @@ export const SearchResultsLimit = () => {
     query: { limit },
     response: { count },
     setLimit,
+    setOffset,
     goToSearchResults
   } = useSearchResources()
 
@@ -25,11 +26,14 @@ export const SearchResultsLimit = () => {
           value={limit || limitOptions[0]}
           onChange={({ option }) => {
             setLimit(option)
+            setOffset(0)
             goToSearchResults()
           }}
         />
       </Box>
-      <Paragraph margin="none">of {count}</Paragraph>
+      <Paragraph margin="none">
+        per page of <Text weight="bold">{count}</Text>
+      </Paragraph>
     </Box>
   )
 }

--- a/client/src/helpers/getPagination.js
+++ b/client/src/helpers/getPagination.js
@@ -1,0 +1,13 @@
+// helpers for handling pagination
+export const offsetToPage = (offset, limit) => {
+  return offset === 0 ? 1 : offset / limit + 1
+}
+
+export const pageToOffset = (page, limit) => {
+  return page === 1 ? 0 : (page - 1) * limit
+}
+
+export const getLastOffset = (count, limit) => {
+  if (!count) return 0
+  return limit > 0 ? Math.floor(count / limit) : 0
+}

--- a/client/src/hooks/useSearchResources.js
+++ b/client/src/hooks/useSearchResources.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import { ResourcesPortalContext } from '../ResourcesPortalContext'
-import { useSearch } from './useSearch'
+import { ResourcesPortalContext } from 'ResourcesPortalContext'
+import { useSearch } from 'hooks/useSearch'
 
 export const useSearchResources = (newSearch) => {
   const { search, setSearch } = React.useContext(ResourcesPortalContext)
@@ -9,9 +9,20 @@ export const useSearchResources = (newSearch) => {
 
   const baseSearch = useSearch(search, setSearch)
 
+  const count = parseInt(search.response.count, 10) || 0
+  const offset = parseInt(search.query.offset, 10) || 0
+  const limit = parseInt(search.query.limit, 10) || 10
+  const last = count && limit > 0 ? Math.floor(count / limit) * limit : 0
+
   return {
     ...baseSearch,
     query: search.query,
-    response: search.response
+    response: search.response,
+    pagination: {
+      count,
+      offset,
+      limit,
+      last
+    }
   }
 }

--- a/client/src/hooks/useSearchResources.js
+++ b/client/src/hooks/useSearchResources.js
@@ -12,7 +12,9 @@ export const useSearchResources = (newSearch) => {
   const count = parseInt(search.response.count, 10) || 0
   const offset = parseInt(search.query.offset, 10) || 0
   const limit = parseInt(search.query.limit, 10) || 10
-  const last = count && limit > 0 ? Math.floor(count / limit) * limit : 0
+  const remainder = count % limit
+  const fromEnd = remainder === 0 ? limit : remainder
+  const last = count && limit > 0 ? count - fromEnd : 0
 
   return {
     ...baseSearch,


### PR DESCRIPTION
## Issue Number

#871 

## Purpose/Implementation Notes

* adds helpers to convert pages to offsets and back
* implements them in the `SearchResultOffset` component
* goes to top of window when you change pages
* updates the component that shows how many per page to say that so it is less confusing

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

tested with various offsets and limits

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a but here

![Screen Shot 2021-06-04 at 2 03 56 PM](https://user-images.githubusercontent.com/1075609/120844640-b5e08800-c53d-11eb-99f3-42781c488e15.png)

