### PR TITLE
872 filtering empty search queries

### DIFF
--- a/api/resources_portal/models/material.py
+++ b/api/resources_portal/models/material.py
@@ -94,7 +94,7 @@ class Material(SafeDeleteModel):
         return not (self.pubmed_id == "")
 
     def has_pre_print(self):
-        return not (self.pre_print_doi == "" and self.pre_print_title == "")
+        return bool(self.pre_print_doi and self.pre_print_title)
 
     @property
     def frontend_URL(self):

--- a/client/src/components/SearchResultsFilters.js
+++ b/client/src/components/SearchResultsFilters.js
@@ -67,9 +67,9 @@ export const SearchResultsFilters = () => {
             <CheckBox
               key={organism.key}
               label={`${organism.key} (${organism.value})`}
-              checked={hasFacet('organism', organism.key)}
+              checked={hasFacet('organisms', organism.key)}
               onChange={({ target: { checked } }) => {
-                toggleFacet(checked, 'organism', organism.key)
+                toggleFacet(checked, 'organisms', organism.key)
                 goToSearchResults(true)
               }}
             />

--- a/client/src/helpers/isSearchableQuery.js
+++ b/client/src/helpers/isSearchableQuery.js
@@ -1,8 +1,5 @@
 // if a category is selected only search is a search term is provided
 
 export default (query) => {
-  if (!query) return false
-  if (query.category && !query.search) return false
-  if (Object.keys(query).length === 0) return false
-  return true
+  return query || Object.keys(query).length !== 0
 }


### PR DESCRIPTION
## Issue Number

#872 

## Purpose/Implementation Notes

* allows filtering for empty search queries
* fixes `organisms` filtering
* fixes `has_pre_print` attribute on material which in turn fixes filtering on that facet

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

tested on search page

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
