### PR TITLE
805 refresh user details

### DIFF
--- a/client/src/components/LoginRequired.js
+++ b/client/src/components/LoginRequired.js
@@ -13,10 +13,14 @@ export default ({
   showHeader = false
 }) => {
   const router = useRouter()
-  const { isLoggedIn } = useUser()
+  const { isLoggedIn, refreshUser } = useUser()
   const hasCode = !!router.query.code
   const isResponsePage = router.pathname === '/account'
   const showLoginModal = hasCode && isResponsePage
+
+  React.useEffect(() => {
+    if (isLoggedIn) refreshUser()
+  }, [])
 
   if (!isLoggedIn) {
     return (

--- a/client/src/pages/account/basic-information/index.js
+++ b/client/src/pages/account/basic-information/index.js
@@ -117,7 +117,7 @@ const BasicInformation = () => {
                 label="Cancel"
                 onClick={() => setShowLogOutModal(false)}
               />
-              <Button critical label="Confirm" onClick={logOut} />
+              <Button critical label="Confirm" onClick={() => logOut()} />
             </Box>
           </Box>
         </Modal>


### PR DESCRIPTION
## Issue Number

#805 

## Purpose/Implementation Notes

* refreshes user data for all pages where we check if they are logged in to see the content
* allows for default redirect after logging out from the `account/basic-information` page

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested logging out and logging back in and making a change and then looking at my teams

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
