### PR TITLE
fixes issue with unable to edit resource and flash of error after save

### DIFF
--- a/client/src/contexts/ResourceContext.js
+++ b/client/src/contexts/ResourceContext.js
@@ -165,7 +165,10 @@ export const ResourceContextProvider = ({
 
   // explicitly destroy local storage
   const clearResourceContext = () => {
-    setResource({})
+    // setting the resource undefined here messes with
+    // rendered views that are on their way out
+    // so it is best to just delete the local storage directly
+    window.localStorage.removeItem(localStorageName)
     setFetched()
     setExistingRequirementsResource()
   }


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Setting the resource to `undefined` was causing an error to flash before navigating away from the page.
Setting it to `{}` fixed the flashing error but prevented the local storage value from being overwritten using the initialValue argument in `useLocalStorage`.

This change cleans up the storage without the error before navigating away from the page.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a tested editing a resource, then navigating away and editing another

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
