### PR TITLE
901 - add help badge on teams page

### DIFF
--- a/client/src/pages/account/teams/index.js
+++ b/client/src/pages/account/teams/index.js
@@ -3,11 +3,18 @@ import { Box, Button, Grid, Text } from 'grommet'
 import Link from 'next/link'
 import { DrillDownNav } from 'components/DrillDownNav'
 import { AccountEmptyPage } from 'components/AccountEmptyPage'
+import HelpLink from 'components/HelpLink'
 import Icon from 'components/Icon'
 import { Loader } from 'components/Loader'
 import { useUser } from 'hooks/useUser'
 import api from 'api'
 import EmptyTeams from '../../../images/empty-teams.svg'
+
+// Don't use label attribute here
+// to allow for parent css styles to apply
+const TeamsHelpLink = () => (
+  <HelpLink path="what-are-teams-and-how-do-i-use-them">Teams</HelpLink>
+)
 
 const Teams = () => {
   // get existing teams (organizations)
@@ -31,7 +38,7 @@ const Teams = () => {
   if (!teams) return <Loader />
 
   return (
-    <DrillDownNav title="Teams">
+    <DrillDownNav title={<TeamsHelpLink />}>
       {teams.length === 0 && (
         <AccountEmptyPage
           paragraphs={[


### PR DESCRIPTION
## Issue Number

#901 

## Purpose/Implementation Notes

* adds a link to all teams related pages to the help section

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a - link works

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2021-07-22 at 5 17 58 PM](https://user-images.githubusercontent.com/1075609/126710787-3485926b-a327-435d-a2b1-8d3f850bf4d1.png)

