### PR TITLE
Make sure the exit code of rportal matches the command it calls.

### DIFF
--- a/bin/rportal
+++ b/bin/rportal
@@ -57,6 +57,12 @@ args = parser.parse_args()
 
 try:
     command = commands[args.command]
-    os.system(command.format(" ".join(args.command_args)))
+    waitstatus = os.system(command.format(" ".join(args.command_args)))
+
+    # The exit code of this script matches the command it called.
+    # os.system() outputs a waitstatus instead of an exitcode.
+    # In python3.9 this becomes the much more sane
+    # os.waitstatus_to_exitcode() function.
+    exit(os.WEXITSTATUS(waitstatus))
 except KeyError:
     print("Unknown Command")


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/scpca-portal/pull/56

## Purpose/Implementation Notes

This repo has the same issue as the other one, so it gets the same fix. See https://github.com/AlexsLemonade/scpca-portal/pull/56 for more details.