### PR TITLE
Taint the API instance so we can test SSL cert persistence.

### DIFF
--- a/infrastructure/deploy.py
+++ b/infrastructure/deploy.py
@@ -144,6 +144,17 @@ def run_terraform(args):
     # Make sure that Terraform is allowed to shut down gracefully.
     try:
         terraform_process = subprocess.Popen(
+            ["terraform", "taint", "aws_instance.api_server_1"], stdout=subprocess.PIPE
+        )
+        output = ""
+        for line in iter(terraform_process.stdout.readline, b""):
+            decoded_line = line.decode("utf-8")
+            print(decoded_line, end="")
+            output += decoded_line
+
+        terraform_process.wait()
+
+        terraform_process = subprocess.Popen(
             ["terraform", "apply", var_file_arg, "-auto-approve"], stdout=subprocess.PIPE
         )
         output = ""


### PR DESCRIPTION
## Issue Number

#923 

## Purpose/Implementation Notes

We stored the SSL cert in S3, but when I redeployed to see if it would use it successfully the API instance didn't get cycled, so I couldn't tell.

I'll make another PR to remove this once it's tested.

## Types of changes

- Temporary test
