### PR TITLE
Update which token is used by the docs workflow.

### DIFF
--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -25,6 +25,8 @@ jobs:
           DJANGO_SECRET_KEY: ${{ secrets.PROD_DJANGO_SECRET_KEY }}
           DOCKER_ID: ${{ secrets.DOCKER_ID }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           API_SSH_KEY: ${{ secrets.API_SSH_KEY }}
           OAUTH_URL: ${{ secrets.PROD_OAUTH_URL }}
           OAUTH_CLIENT_ID: ${{ secrets.PROD_OAUTH_CLIENT_ID }}

--- a/.github/workflows/deploy_prod_backend.yml
+++ b/.github/workflows/deploy_prod_backend.yml
@@ -25,8 +25,6 @@ jobs:
           DJANGO_SECRET_KEY: ${{ secrets.PROD_DJANGO_SECRET_KEY }}
           DOCKER_ID: ${{ secrets.DOCKER_ID }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           API_SSH_KEY: ${{ secrets.API_SSH_KEY }}
           OAUTH_URL: ${{ secrets.PROD_OAUTH_URL }}
           OAUTH_CLIENT_ID: ${{ secrets.PROD_OAUTH_CLIENT_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          # github_token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
           # Enable linters
           # Temporarily disabled: https://github.com/wearerequired/lint-action/issues/88
           # black: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          # github_token: ${{ secrets.DOCS_BOT_GITHUB_TOKEN }}
           # Enable linters
           # Temporarily disabled: https://github.com/wearerequired/lint-action/issues/88
           # black: true


### PR DESCRIPTION
## Issue Number

I think I missed this in https://github.com/AlexsLemonade/resources-portal/pull/921

## Purpose/Implementation Notes

This should have changed. I also think the one used for linting was unnecessary.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)