### PR TITLE
935 upgrade to postgres major version 12.5

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -1,6 +1,7 @@
 # This terraform file hosts the resources directly related to the
 # postgres RDS instance.
 
+### Start Delete After Upgrade to Postgres 12.5
 # Currently exists, will be deleted after aws_db_parameter_group.postgres_parameters is in use.
 resource "aws_db_parameter_group" "postgres_parameters" {
   name = "postgres-parameters-${var.user}-${var.stage}"
@@ -35,13 +36,40 @@ resource "aws_db_parameter_group" "postgres_parameters_new" {
 
   tags = var.default_tags
 }
+### End Delete After Upgrade to Postgres 12.5
+
+resource "aws_db_parameter_group" "postgres12_parameters" {
+  name = "resources-portal-postgres-parameters-${var.user}-${var.stage}"
+  description = "Postgres Parameters ${var.user} ${var.stage}"
+  family = "postgres12"
+
+  parameter {
+    name = "deadlock_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  parameter {
+    name = "statement_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.default_tags
+}
 
 resource "aws_db_instance" "postgres_db" {
   identifier = "resources-portal-${var.user}-${var.stage}"
   allocated_storage = 100
   storage_type = "gp2"
+  # start temp upgrade options
+  allow_major_version_upgrade = true
+  apply_immediately = true
+  # end temp upgrade options
   engine = "postgres"
-  engine_version = "9.6.20"
+  engine_version = "12.5"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   name = "resources_portal"
@@ -50,7 +78,7 @@ resource "aws_db_instance" "postgres_db" {
   password = var.database_password
 
   db_subnet_group_name = aws_db_subnet_group.resources_portal.name
-  parameter_group_name = aws_db_parameter_group.postgres_parameters_new.name
+  parameter_group_name = aws_db_parameter_group.postgres12_parameters.name
 
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417

--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "9.6.11"
+  engine_version = "9.6.20"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   name = "resources_portal"


### PR DESCRIPTION
## Issue Number

#935 

## Purpose/Implementation Notes

* Adds new postgres12 parameter group
* set new parameter group on db instance
* sets postgres engine_version to 12.5
* temporarily allows major version upgrade

Must wait for #940 

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
