### PR TITLE
comment out owners for ami

### DIFF
--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -7,7 +7,9 @@ data "local_file" "api_nginx_config" {
 
 data "aws_ami" "ubuntu" {
   most_recent = true
-  owners = ["190047108236"]
+  # specifying owners makes this throw an error
+  # https://github.com/hashicorp/terraform-provider-aws/issues/5996#issuecomment-424816078
+  # owners = ["190047108236"]
 
   filter {
     name   = "name"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Was trying to deploy to staging backend and encountered an error with terraform. Not entirely sure what is causing it but apparently people are reporting that the issue is resolved by removing the `owners` attribute in the ami block. 

This is a PR to test that change.

Reference:
https://github.com/hashicorp/terraform-provider-aws/issues/5996#issuecomment-424816078

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
