### PR TITLE
954 aws ami ubuntu missing

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -17,9 +17,13 @@ cat <<"EOF" > nginx.conf
 ${nginx_config}
 EOF
 apt-get update -y
-apt-get install nginx awscli zip docker-ce -y
+apt-get install nginx awscli zip -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
+
+# install and run docker
+apt-get install docker-ce -y
+service docker restart
 
 if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     # Check here for the cert in S3, if present install, if not run certbot.

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -24,47 +24,47 @@ service nginx restart
 if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     # Check here for the cert in S3, if present install, if not run certbot.
     if [[ $(aws s3 ls "${resources_portal_cert_bucket}" | wc -l) == "0" ]]; then
-	# Create and install SSL Certificate for the API.
-	# Only necessary on staging and prod.
-	# We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-	apt-get install -y software-properties-common
-	add-apt-repository ppa:certbot/certbot
-	apt-get update
-	apt-get install -y python-certbot-nginx
+      # Create and install SSL Certificate for the API.
+      # Only necessary on staging and prod.
+      # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
+      apt-get install -y software-properties-common
+      add-apt-repository ppa:certbot/certbot
+      apt-get update
+      apt-get install -y python-certbot-nginx
 
-	# g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
-	# have configured to forward mail to the #teamcontact channel in
-	# slack. Certbot will use it for "important account
-	# notifications".
+      # g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
+      # have configured to forward mail to the #teamcontact channel in
+      # slack. Certbot will use it for "important account
+      # notifications".
 
-	# The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
-	sleep 180
-	BASE_URL="resources.alexslemonade.org"
-	if [[ ${stage} == "staging" ]]; then
-            certbot --nginx -d api.staging.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-	elif [[ ${stage} == "prod" ]]; then
-            certbot --nginx -d api.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-	fi
+      # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+      sleep 180
+      BASE_URL="resources.alexslemonade.org"
+      if [[ ${stage} == "staging" ]]; then
+          certbot --nginx -d api.staging.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+      elif [[ ${stage} == "prod" ]]; then
+          certbot --nginx -d api.$BASE_URL -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+      fi
 
-	# Add the nginx.conf file that certbot setup to the zip dir.
-	cp /etc/nginx/nginx.conf /etc/letsencrypt/
+      # Add the nginx.conf file that certbot setup to the zip dir.
+      cp /etc/nginx/nginx.conf /etc/letsencrypt/
 
-	cd /etc/letsencrypt/ || exit
-	sudo zip -r ../letsencryptdir.zip "../$(basename "$PWD")"
+      cd /etc/letsencrypt/ || exit
+      sudo zip -r ../letsencryptdir.zip "../$(basename "$PWD")"
 
-	# And then cleanup the extra copy.
-	rm /etc/letsencrypt/nginx.conf
+      # And then cleanup the extra copy.
+      rm /etc/letsencrypt/nginx.conf
 
-	cd - || exit
-	mv /etc/letsencryptdir.zip .
-	aws s3 cp letsencryptdir.zip "s3://${resources_portal_cert_bucket}/"
-	rm letsencryptdir.zip
-    else
-	zip_filename=$(aws s3 ls "${resources_portal_cert_bucket}" | head -1 | awk '{print $4}')
-	aws s3 cp "s3://${resources_portal_cert_bucket}/$zip_filename" letsencryptdir.zip
-	unzip letsencryptdir.zip -d /etc/
-	mv /etc/letsencrypt/nginx.conf /etc/nginx/
-	service nginx restart
+      cd - || exit
+      mv /etc/letsencryptdir.zip .
+      aws s3 cp letsencryptdir.zip "s3://${resources_portal_cert_bucket}/"
+      rm letsencryptdir.zip
+      else
+      zip_filename=$(aws s3 ls "${resources_portal_cert_bucket}" | head -1 | awk '{print $4}')
+      aws s3 cp "s3://${resources_portal_cert_bucket}/$zip_filename" letsencryptdir.zip
+      unzip letsencryptdir.zip -d /etc/
+      mv /etc/letsencrypt/nginx.conf /etc/nginx/
+      service nginx restart
     fi
 fi
 

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -17,7 +17,7 @@ cat <<"EOF" > nginx.conf
 ${nginx_config}
 EOF
 apt-get update -y
-apt-get install nginx awscli zip -y
+apt-get install nginx awscli zip docker-ce -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 

--- a/infrastructure/api.tf
+++ b/infrastructure/api.tf
@@ -7,15 +7,13 @@ data "local_file" "api_nginx_config" {
 
 data "aws_ami" "ubuntu" {
   most_recent = true
-  # specifying owners makes this throw an error
-  # https://github.com/hashicorp/terraform-provider-aws/issues/5996#issuecomment-424816078
-  # owners = ["190047108236"]
+  owners = ["099720109477"]
 
   filter {
     name   = "name"
     # This is a HVM, EBS backed SSD Ubuntu LTS AMI with Docker version 17.12.0 on it in the US,
     # the stock Ubuntu cloud image in the EU.
-    values = ["ubuntu-18-04-docker2"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22*amd64-server*"]
   }
 
   filter {


### PR DESCRIPTION
## Issue Number

#954 

## Purpose/Implementation Notes

The AMI image were were using is no longer available. This PR does the following:

- Update from Ubuntu 18 -> 22
- Installs and restarts docker-ce in user-data script

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

N/A want to test in staging

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
