### PR TITLE
postgres 12.11

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "12.7"
+  engine_version = "12.11"
   auto_minor_version_upgrade = false
   instance_class = var.database_instance_type
   name = "resources_portal"


### PR DESCRIPTION
## Issue Number

n/a

```InvalidParameterCombination: Cannot upgrade postgres from 12.11 to 12.7```

## Purpose/Implementation Notes

postgres minor version updated before terraform caught up, this matches them
- postgres 12.7 -> 12.11

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
