### PR TITLE
postgres 12.19 instance type t2.micro -> t3.micro

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -53,7 +53,7 @@ variable "api_instance_type" {
 }
 
 variable "database_instance_type" {
-  default = "db.t2.micro"
+  default = "db.t3.micro"
 }
 
 variable "elasticsearch_instance_type" {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Deploy isnt working because db instance type is no longer supported, this updates to a supported t3 instance type.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A